### PR TITLE
Fixes to train.common.tile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,11 +27,18 @@ minecraft {
 }
 
 dependencies {
+    repositories {
+        ivy {
+            name "BuildCraft"
+            artifactPattern "http://www.mod-buildcraft.com/releases/BuildCraft/[revision]/[module]-[revision](-[classifier]).[ext]"
+        }
+    }
     // you may put jars on which you depend on in ./libs
     // or you may define them like so..
     //compile "some.group:artifact:version:classifier"
     //compile "some.group:artifact:version"
-      
+	
+    compile name: "buildcraft", version: "7.1.16", classifier: "dev"
     // real examples
     //compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'  // adds buildcraft to the dev env
     //compile 'com.googlecode.efficient-java-matrix-library:ejml:0.24' // adds ejml to the dev env

--- a/src/main/java/src/train/common/core/util/Energy.java
+++ b/src/main/java/src/train/common/core/util/Energy.java
@@ -1,0 +1,41 @@
+package src.train.common.core.util;
+
+public final class Energy {
+	private float rf;
+	
+	private Energy(float rf) {
+		this.rf = rf;
+	}
+	
+	public static Energy zero() {
+		return new Energy(0);
+	}
+	
+	public static Energy fromRF(float rf) {
+		return new Energy(rf);
+	}
+	
+	public static Energy fromEU(float eu) {
+		return new Energy(eu * 4);
+	}
+	
+	public static Energy fromMJ(float mj) {
+		return new Energy(mj * 10);
+	}
+	
+	public Energy copy() {
+		return new Energy(this.rf);
+	}
+	
+	public float toRF() {
+		return rf;
+	}
+	
+	public float toEU() {
+		return rf / 4;
+	}
+	
+	public float toMJ() {
+		return rf / 10;
+	}
+}

--- a/src/main/java/src/train/common/recipes/DistilRecipes.java
+++ b/src/main/java/src/train/common/recipes/DistilRecipes.java
@@ -60,19 +60,20 @@ public class DistilRecipes {
 		return this.experienceList.containsKey(Integer.valueOf(i)) ? ((Float) this.experienceList.get(Integer.valueOf(i))).floatValue() : 0.0F;
 	}
 
-	public int getPlasticChance(int i) {
-		if (this.plasticChanceList.containsKey(Integer.valueOf(i))) {
-			return (int) ((Float) this.plasticChanceList.get(Integer.valueOf(i))).floatValue();
+	public int getPlasticChance(Item item) {
+		int i = Item.getIdFromItem(item);
+		if (this.plasticChanceList.containsKey(i)) {
+			return (int) ((Float) this.plasticChanceList.get(i)).floatValue();
 		}
 		return 0;
 	}
 
-	public ItemStack getSmeltingResult(int i) {
-		return (ItemStack) smeltingList.get(Integer.valueOf(i));
+	public ItemStack getSmeltingResult(Item i) {
+		return (ItemStack) smeltingList.get(Item.getIdFromItem(i));
 	}
 
-	public ItemStack getPlasticResult(int i) {
-		return (ItemStack) plasticList.get(Integer.valueOf(i));
+	public ItemStack getPlasticResult(Item i) {
+		return (ItemStack) plasticList.get(Item.getIdFromItem(i));
 	}
 
 	public Map getSmeltingList() {

--- a/src/main/java/src/train/common/tile/TileCrafterTierI.java
+++ b/src/main/java/src/train/common/tile/TileCrafterTierI.java
@@ -103,7 +103,7 @@ public class TileCrafterTierI extends TileEntity implements IInventory, ITier {
 		NBTTagList nbttaglist = nbtTag.getTagList("Items", Constants.NBT.TAG_COMPOUND);
 		this.crafterInventory = new ItemStack[this.getSizeInventory()];
 		for (int i = 0; i < nbttaglist.tagCount(); i++) {
-			NBTTagCompound nbttagcompound1 = (NBTTagCompound) nbttaglist.getCompoundTagAt(i);
+			NBTTagCompound nbttagcompound1 = nbttaglist.getCompoundTagAt(i);
 			byte byte0 = nbttagcompound1.getByte("Slot");
 			if (byte0 >= 0 && byte0 < crafterInventory.length) {
 				this.crafterInventory[byte0] = ItemStack.loadItemStackFromNBT(nbttagcompound1);
@@ -112,7 +112,7 @@ public class TileCrafterTierI extends TileEntity implements IInventory, ITier {
 
 		NBTTagList nbttaglist2 = nbtTag.getTagList("Known", Constants.NBT.TAG_COMPOUND);
 		for (int i = 0; i < nbttaglist2.tagCount(); i++) {
-			NBTTagCompound nbttagcompound2 = (NBTTagCompound) nbttaglist2.getCompoundTagAt(i);
+			NBTTagCompound nbttagcompound2 = nbttaglist2.getCompoundTagAt(i);
 			byte byte1 = nbttagcompound2.getByte("Recipe");
 			if (byte1 >= 0) {
 				if (!listContains(knownRecipes, ItemStack.loadItemStackFromNBT(nbttagcompound2))) {

--- a/src/main/java/src/train/common/tile/TileCrafterTierII.java
+++ b/src/main/java/src/train/common/tile/TileCrafterTierII.java
@@ -6,11 +6,13 @@ import java.util.Random;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.network.Packet;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.ForgeDirection;
 import src.train.common.core.handlers.PacketHandler;
 import src.train.common.core.interfaces.ITier;
@@ -89,7 +91,7 @@ public class TileCrafterTierII extends TileEntity implements IInventory, ITier {
 	}
 
 	@Override
-	public String getInvName() {
+	public String getInventoryName() {
 		return "TierII";
 	}
 
@@ -98,19 +100,19 @@ public class TileCrafterTierII extends TileEntity implements IInventory, ITier {
 		super.readFromNBT(nbtTag);
 		facing = ForgeDirection.getOrientation(nbtTag.getByte("Orientation"));
 		slotSelected = nbtTag.getIntArray("Selected");
-		NBTTagList nbttaglist = nbtTag.getTagList("Items");
+		NBTTagList nbttaglist = nbtTag.getTagList("Items", Constants.NBT.TAG_COMPOUND);
 		this.crafterInventory = new ItemStack[this.getSizeInventory()];
 		for (int i = 0; i < nbttaglist.tagCount(); i++) {
-			NBTTagCompound nbttagcompound1 = (NBTTagCompound) nbttaglist.tagAt(i);
+			NBTTagCompound nbttagcompound1 = nbttaglist.getCompoundTagAt(i);
 			byte byte0 = nbttagcompound1.getByte("Slot");
 			if (byte0 >= 0 && byte0 < crafterInventory.length) {
 				this.crafterInventory[byte0] = ItemStack.loadItemStackFromNBT(nbttagcompound1);
 			}
 		}
 
-		NBTTagList nbttaglist2 = nbtTag.getTagList("Known");
+		NBTTagList nbttaglist2 = nbtTag.getTagList("Known", Constants.NBT.TAG_COMPOUND);
 		for (int i = 0; i < nbttaglist2.tagCount(); i++) {
-			NBTTagCompound nbttagcompound2 = (NBTTagCompound) nbttaglist2.tagAt(i);
+			NBTTagCompound nbttagcompound2 = nbttaglist2.getCompoundTagAt(i);
 			byte byte1 = nbttagcompound2.getByte("Recipe");
 			if (byte1 >= 0) {
 				if (!listContains(knownRecipes, ItemStack.loadItemStackFromNBT(nbttagcompound2))) {
@@ -158,7 +160,7 @@ public class TileCrafterTierII extends TileEntity implements IInventory, ITier {
 	}
 
 	@Override
-	public void onInventoryChanged() {
+	public void markDirty() {
 		resultList.clear();
 		for (int i = 10; i < crafterInventory.length - 8; i++) {
 			crafterInventory[i] = null;
@@ -171,7 +173,7 @@ public class TileCrafterTierII extends TileEntity implements IInventory, ITier {
 			if (stack != null) {
 				if((count+10)<crafterInventory.length) {
 					resultList.add(stack);
-					crafterInventory[count + 10] = new ItemStack(stack.itemID, 1, 0);
+					crafterInventory[count + 10] = new ItemStack(stack.getItem(), 1, 0);
 				}
 				count++;
 			}
@@ -188,7 +190,7 @@ public class TileCrafterTierII extends TileEntity implements IInventory, ITier {
 		if (worldObj == null) {
 			return true;
 		}
-		if (worldObj.getBlockTileEntity(xCoord, yCoord, zCoord) != this) {
+		if (worldObj.getTileEntity(xCoord, yCoord, zCoord) != this) {
 			return false;
 		}
 		return entityplayer.getDistanceSq((double) xCoord + 0.5D, (double) yCoord + 0.5D, (double) zCoord + 0.5D) <= 64D;
@@ -204,10 +206,10 @@ public class TileCrafterTierII extends TileEntity implements IInventory, ITier {
 	}
 
 	@Override
-	public void openChest() {}
+	public void openInventory() {}
 
 	@Override
-	public void closeChest() {}
+	public void closeInventory() {}
 
 	@Override
 	public Packet getDescriptionPacket() {
@@ -220,7 +222,7 @@ public class TileCrafterTierII extends TileEntity implements IInventory, ITier {
 
 	private boolean listContains(List<ItemStack> list, ItemStack stack) {
 		for (int i = 0; i < list.size(); i++) {
-			if (list.get(i).itemID == stack.itemID) {
+			if (Item.getIdFromItem(list.get(i).getItem()) == Item.getIdFromItem(stack.getItem())) {
 				return true;
 			}
 		}
@@ -258,7 +260,7 @@ public class TileCrafterTierII extends TileEntity implements IInventory, ITier {
 	}
 
 	@Override
-	public boolean isInvNameLocalized() {
+	public boolean hasCustomInventoryName() {
 		return false;
 	}
 

--- a/src/main/java/src/train/common/tile/TileEntityOpenHearthFurnace.java
+++ b/src/main/java/src/train/common/tile/TileEntityOpenHearthFurnace.java
@@ -5,6 +5,8 @@ import java.util.Random;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -13,6 +15,7 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.network.Packet;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.ForgeDirection;
 import src.train.common.blocks.BlockOpenHearthFurnace;
 import src.train.common.core.handlers.PacketHandler;
@@ -101,10 +104,10 @@ public class TileEntityOpenHearthFurnace extends TileEntity implements IInventor
 	public void readFromNBT(NBTTagCompound nbtTag) {
 		super.readFromNBT(nbtTag);
 		facing = ForgeDirection.getOrientation(nbtTag.getByte("Orientation"));
-		NBTTagList nbttaglist = nbtTag.getTagList("Items");
+		NBTTagList nbttaglist = nbtTag.getTagList("Items", Constants.NBT.TAG_COMPOUND);
 		furnaceItemStacks = new ItemStack[getSizeInventory()];
 		for (int i = 0; i < nbttaglist.tagCount(); i++) {
-			NBTTagCompound nbttagcompound1 = (NBTTagCompound) nbttaglist.tagAt(i);
+			NBTTagCompound nbttagcompound1 = nbttaglist.getCompoundTagAt(i);
 			byte byte0 = nbttagcompound1.getByte("Slot");
 			if (byte0 >= 0 && byte0 < furnaceItemStacks.length) {
 				this.furnaceItemStacks[byte0] = ItemStack.loadItemStackFromNBT(nbttagcompound1);
@@ -207,7 +210,7 @@ public class TileEntityOpenHearthFurnace extends TileEntity implements IInventor
 			}
 		}
 		if (flag1) {
-			onInventoryChanged();
+			markDirty();
 		}
 	}
 
@@ -290,29 +293,28 @@ public class TileEntityOpenHearthFurnace extends TileEntity implements IInventor
 			return 0;
 		}
 		Item var1 = it.getItem();
-		if (var1 < 256 && Block.blocksList[var1].blockMaterial == Material.wood)
+		if (Item.getIdFromItem(var1) < 256 && Block.getBlockFromItem(var1).getMaterial() == Material.wood)
 			return 300;
-		else if (var1 == Item.itemRegistry.getObject("stick"))
+		if (var1 == Items.stick)
 			return 100;
-		else if (var1 == Item.itemRegistry.getObject("coal"))
+		if (var1 == Items.coal)
 			return 2600;
-		else if (var1 == Item.itemRegistry.getObject("bucketLava"))
+		if (var1 == Items.lava_bucket)
 			return 20000;
-		else if (var1 == Block.sapling.blockID)
+		if (var1 == Item.getItemFromBlock(Blocks.sapling))
 			return 100;
-		else if (var1 == Item.itemRegistry.getObject("blazeRod"))
+		if (var1 == Items.blaze_rod)
 			return 2500;
-		else if (var1 == BlockIDs.oreTC.blockID && it.getItemDamage() == 1)
+		if (var1 == Item.getItemFromBlock(BlockIDs.oreTC.block) && it.getItemDamage() == 1)
 			return 2500;
-		else if (var1 == BlockIDs.oreTC.blockID && it.getItemDamage() == 2)
+		if (var1 == Item.getItemFromBlock(BlockIDs.oreTC.block) && it.getItemDamage() == 2)
 			return 2500;
-		else if (var1 == ItemIDs.diesel.itemID)
+		if (var1 == ItemIDs.diesel.item)
 			return 4000;
-		else if (var1 == ItemIDs.refinedFuel.itemID)
+		if (var1 == ItemIDs.refinedFuel.item)
 			return 6000;
 		int ret = GameRegistry.getFuelValue(it);
 		return ret;
-
 	}
 
 	@Override

--- a/src/main/java/src/train/common/tile/TileEntityOverheadLines.java
+++ b/src/main/java/src/train/common/tile/TileEntityOverheadLines.java
@@ -61,6 +61,7 @@ public class TileEntityOverheadLines extends TileEntity implements IEnergySink{
 			 * IC2
 			 */
 			if (isSimulating()&&!addedToEnergyNet) {
+				//TODO: This is require by IC2 to know about this energy tile
 				//MinecraftForge.EVENT_BUS.post(new EnergyTileLoadEvent(this));
 			}
 		}
@@ -153,12 +154,12 @@ public class TileEntityOverheadLines extends TileEntity implements IEnergySink{
 		Front=par1NBTTagCompound.getBoolean("Front");
 	}
 	@Override
-	public double demandedEnergyUnits() {
+	public double getDemandedEnergy() {
 		return this.getMaxEnergy() - this.getEnergy();
 	}
 
 	@Override
-	public double injectEnergyUnits(ForgeDirection directionFrom, double amount) {
+	public double injectEnergy(ForgeDirection directionFrom, double amount, double voltage) {
 		this.energy+=amount;
 		isProvider = true;
 		if(this.energy>this.getMaxEnergy()){
@@ -168,6 +169,13 @@ public class TileEntityOverheadLines extends TileEntity implements IEnergySink{
 		}
 		return 0;
 	}
+
+	@Override
+	public int getSinkTier() {
+		// NOTE: This was deduced from previously existing getMaxSafeInputs value 1024
+		return 3; // High Voltage
+	}
+	
 	public double getEnergy() {
 		return this.energy;
 	}
@@ -178,10 +186,7 @@ public class TileEntityOverheadLines extends TileEntity implements IEnergySink{
 	public double getMaxEnergy() {
 		return this.maxEnergy;
 	}
-	@Override
-	public int getMaxSafeInput() {
-		return 1024;
-	}
+	
 	@Override
 	public boolean acceptsEnergyFrom(TileEntity emitter,
 			ForgeDirection direction) {

--- a/src/main/java/src/train/common/tile/TileTrainWbench.java
+++ b/src/main/java/src/train/common/tile/TileTrainWbench.java
@@ -14,6 +14,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.network.Packet;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.ForgeDirection;
 import src.train.common.core.handlers.PacketHandler;
 
@@ -99,10 +100,10 @@ public class TileTrainWbench extends TileEntity implements IInventory {
 	public void readFromNBT(NBTTagCompound nbtTag) {
 		super.readFromNBT(nbtTag);
 		facing = ForgeDirection.getOrientation(nbtTag.getByte("Orientation"));
-		NBTTagList tagList = nbtTag.getTagList("Items");
+		NBTTagList tagList = nbtTag.getTagList("Items", Constants.NBT.TAG_COMPOUND);
 		workbenchItemStacks = new ItemStack[getSizeInventory()];
 		for (int i = 0; i < tagList.tagCount(); ++i) {
-			NBTTagCompound tagCompound = (NBTTagCompound) tagList.tagAt(i);
+			NBTTagCompound tagCompound = tagList.getCompoundTagAt(i);
 			byte slot = tagCompound.getByte("Slot");
 			if (slot >= 0 && slot < workbenchItemStacks.length) {
 				workbenchItemStacks[slot] = ItemStack.loadItemStackFromNBT(tagCompound);

--- a/src/main/java/src/train/common/tile/TileWaterWheel.java
+++ b/src/main/java/src/train/common/tile/TileWaterWheel.java
@@ -27,7 +27,7 @@ import src.train.common.core.handlers.PacketHandler;
 import src.train.common.library.Info;
 import cpw.mods.fml.common.FMLCommonHandler;
 
-public class TileWaterWheel extends TileEntity/*TileEntityElectrical*/ implements IEnergySource{
+public class TileWaterWheel extends TileEntity/*TileEntityElectrical*/ implements IEnergySource {
 	private int facingMeta;
 	private int waterDirection;
 	Material blockMaterial;
@@ -307,13 +307,12 @@ public class TileWaterWheel extends TileEntity/*TileEntityElectrical*/ implement
 	public boolean isAddedToEnergyNet() {
 		return this.addedToEnergyNet;
 	}*/
-	/**
-	 * IC2
-	 * @return
-	 */
+	
 	@Override
-	public int getMaxEnergyOutput() {
-		return this.production;
+	public int getSourceTier() {
+		// TODO: Should this really be this low or is there a mistake?
+		// NOTE: This was deduced from previously existing getMaxEnergyOutput
+		return 0; //Microvoltage
 	}
 	/*@Override
 	public float getRequest(ForgeDirection direction) {

--- a/src/main/java/src/train/common/tile/TileWindMill.java
+++ b/src/main/java/src/train/common/tile/TileWindMill.java
@@ -145,8 +145,14 @@ public class TileWindMill extends TileEntity implements IEnergySource {
 		return true;
 	}
 
-	@Override
 	public int getMaxEnergyOutput() {return 10;}
+	
+	@Override
+	public int getSourceTier() {
+		// TODO: Should this really be this low or is there a mistake?
+		// NOTE: This was deduced from getMaxEnergyOutput
+		return 1; //Low Voltage
+	}
 
 	@Override
 	public boolean emitsEnergyTo(TileEntity receiver, ForgeDirection direction) {


### PR DESCRIPTION
- Added buildcraft to gradle dependency (Seemed to work in commandline
  gradle, but Eclipse didn't want to cooperate because of JAVA_HOME)
- Crafting result getters moved to use Items
- Getting NBTTagList now takes in the type of tag inside the list
- Getting NBTTagCompound now has better method
- getInvName -> getInventoryName
- onInventoryChanged -> markDirty
- .itemID -> .getItem()
- getBlockTileEntity -> getTileEntity
- *Chest -> *Inventory
- isInvNameLocalized -> hasCustomInventoryName
- .fluidID -> .getFluidID()
- Using Items and Blocks insted of IDs.
- demandedEnergyUnits -> getDemandedEnergy
- injectEnergyUnits -> injectEnergy
- getSinkTier added from IC2 (I tried to deduce the tiers for things,
  but the results seemed too small)
- getMaxSafeInput has been removed
- Rewrote most of TileGeneratorDiesel to use new RF based Buildcraft
  - There is now train.common.core.util.Energy which allows easy
    translation between EU, RF and MJ.
  - Because Buildcraft moving away from RF PowerHandler had dissapeared,
    which what I can tell was responsible for making sure MJ worked as it
    does
  - There was unnessary byte in the NBT data for diesel generators
    rotation, which has now been removed
