### PR TITLE
Fixing train.common.core.handlers and train.common.core.managers

### DIFF
--- a/src/main/java/src/train/common/core/handlers/AchievementHandler.java
+++ b/src/main/java/src/train/common/core/handlers/AchievementHandler.java
@@ -7,6 +7,9 @@
 
 package src.train.common.core.handlers;
 
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.stats.Achievement;
 import net.minecraftforge.common.AchievementPage;
 import src.train.common.library.AchievementIDs;
@@ -19,51 +22,67 @@ import cpw.mods.fml.relauncher.SideOnly;
 public class AchievementHandler {
 
 	public static AchievementPage tmPage;
+	
+	private static Achievement achievement(String name, int column, int row, Block block, Achievement parent) {
+		return achievement(name, column, row, new ItemStack(block), parent);
+	}
+	
+	private static Achievement achievement(String name, int column, int row, Item item, Achievement parent) {
+		return achievement(name, column, row, new ItemStack(item), parent);
+	}
+	
+	private static Achievement achievement(String name, int column, int row, ItemStack stack, Achievement parent) {
+		Achievement result = new Achievement("achievement.tc." + name, "tc." + name, column, row, stack, parent);
+		if(stack == null) {
+			result.initIndependentStat();
+		}
+		return result.registerStat();
+	}
 
 	public static void load() {
-		AchievementIDs.trainWB.achievement = new Achievement(20121, "trainWB", 0, 0, BlockIDs.trainWorkbench.block, (Achievement) null).setIndependent().registerAchievement();
-		AchievementIDs.woodenParts.achievement = new Achievement(20129, "woodenParts", -2, 2, ItemIDs.woodenBogie.item, AchievementIDs.trainWB.achievement).registerAchievement();
-		AchievementIDs.ironParts.achievement = new Achievement(20130, "ironParts", 0, 2, ItemIDs.ironBogie.item, AchievementIDs.trainWB.achievement).registerAchievement();
-		AchievementIDs.steelParts.achievement = new Achievement(20131, "steelParts", 2, 2, ItemIDs.bogie.item, AchievementIDs.trainWB.achievement).registerAchievement();
-		AchievementIDs.firebox.achievement = new Achievement(20116, "firebox", 0, 4, ItemIDs.firebox.item, AchievementIDs.ironParts.achievement).registerAchievement();
-		AchievementIDs.zeppelin.achievement = new Achievement(20117, "zeppelin", 2, 4, ItemIDs.airship.item, AchievementIDs.firebox.achievement).registerAchievement();
-		AchievementIDs.smallSteam.achievement = new Achievement(20100, "smallSteam", -2, 6, ItemIDs.minecartLoco3.item, AchievementIDs.firebox.achievement).registerAchievement();
-		AchievementIDs.normalSteam.achievement = new Achievement(20101, "normalSteam", 0, 6, ItemIDs.minecartPower.item, AchievementIDs.firebox.achievement).registerAchievement();
-		//AchievementIDs.heavySteam.achievement = new Achievement(20109, "heavySteam", 2, 6, ItemIDs.minecartHeavySteam.item, AchievementIDs.firebox.achievement).registerAchievement();
+		AchievementIDs.trainWB.achievement = achievement("trainWB", 0, 0, BlockIDs.trainWorkbench.block, (Achievement) null);
+		AchievementIDs.woodenParts.achievement = achievement("woodenParts", -2, 2, ItemIDs.woodenBogie.item, AchievementIDs.trainWB.achievement);
+		AchievementIDs.ironParts.achievement = achievement("ironParts", 0, 2, ItemIDs.ironBogie.item, AchievementIDs.trainWB.achievement);
+		AchievementIDs.steelParts.achievement = achievement("steelParts", 2, 2, ItemIDs.bogie.item, AchievementIDs.trainWB.achievement);
+		AchievementIDs.firebox.achievement = achievement("firebox", 0, 4, ItemIDs.firebox.item, AchievementIDs.ironParts.achievement);
+		AchievementIDs.zeppelin.achievement = achievement("zeppelin", 2, 4, ItemIDs.airship.item, AchievementIDs.firebox.achievement);
+		AchievementIDs.smallSteam.achievement = achievement("smallSteam", -2, 6, ItemIDs.minecartLoco3.item, AchievementIDs.firebox.achievement);
+		AchievementIDs.normalSteam.achievement = achievement("normalSteam", 0, 6, ItemIDs.minecartPower.item, AchievementIDs.firebox.achievement);
+		//AchievementIDs.heavySteam.achievement = achievement("heavySteam", 2, 6, ItemIDs.minecartHeavySteam.item, AchievementIDs.firebox.achievement);
 		//TODO put it back once Heavy Steam is back
 
-		AchievementIDs.openHearth.achievement = new Achievement(20122, "openHearth", -4, 0, BlockIDs.openFurnaceActive.block, (Achievement) null).setIndependent().registerAchievement();
-		AchievementIDs.steel.achievement = new Achievement(20119, "steel", -4, 2, ItemIDs.steel.item, AchievementIDs.openHearth.achievement).registerAchievement();
-		AchievementIDs.stake.achievement = new Achievement(20118, "stake", -4, 4, ItemIDs.stake.item, AchievementIDs.steel.achievement).registerAchievement();
-		AchievementIDs.dieselEngine.achievement = new Achievement(20115, "dieselEngine", -6, 4, ItemIDs.dieselengine.item, AchievementIDs.steel.achievement).registerAchievement();
-		AchievementIDs.diesel.achievement = new Achievement(20106, "dieselLoco", -6, 6, ItemIDs.minecartCD742.item, AchievementIDs.dieselEngine.achievement).registerAchievement();
+		AchievementIDs.openHearth.achievement = achievement("openHearth", -4, 0, BlockIDs.openFurnaceActive.block, (Achievement) null);
+		AchievementIDs.steel.achievement = achievement("steel", -4, 2, ItemIDs.steel.item, AchievementIDs.openHearth.achievement);
+		AchievementIDs.stake.achievement = achievement("stake", -4, 4, ItemIDs.stake.item, AchievementIDs.steel.achievement);
+		AchievementIDs.dieselEngine.achievement = achievement("dieselEngine", -6, 4, ItemIDs.dieselengine.item, AchievementIDs.steel.achievement);
+		AchievementIDs.diesel.achievement = achievement("dieselLoco", -6, 6, ItemIDs.minecartCD742.item, AchievementIDs.dieselEngine.achievement);
 
-		AchievementIDs.distilationTower.achievement = new Achievement(20123, "distilationTower", -10, 0, BlockIDs.distilActive.block, (Achievement) null).setIndependent().registerAchievement();
-		AchievementIDs.dieselFuel.achievement = new Achievement(20113, "dieselFuel", -8, 2, ItemIDs.diesel.item, AchievementIDs.distilationTower.achievement).registerAchievement();
-		AchievementIDs.plastic.achievement = new Achievement(20124, "plastic", -12, 2, ItemIDs.rawPlastic.item, AchievementIDs.distilationTower.achievement).registerAchievement();
-		AchievementIDs.fineCopperWire.achievement = new Achievement(20125, "fineCopperWire", -12, 4, ItemIDs.copperWireFine.item, AchievementIDs.plastic.achievement).registerAchievement();
-		AchievementIDs.electronicCircuit.achievement = new Achievement(20126, "electronicCircuit", -12, 6, ItemIDs.electronicCircuit.item, AchievementIDs.fineCopperWire.achievement).registerAchievement();
-		AchievementIDs.generator.achievement = new Achievement(20127, "generator", -14, 8, ItemIDs.generator.item, AchievementIDs.electronicCircuit.achievement).registerAchievement();
-		AchievementIDs.electMotor.achievement = new Achievement(20114, "electMotor", -10, 8, ItemIDs.electmotor.item, AchievementIDs.electronicCircuit.achievement).registerAchievement();
-		AchievementIDs.tram.achievement = new Achievement(20107, "tram", -12, 10, ItemIDs.minecartTramWood.item, AchievementIDs.electMotor.achievement).registerAchievement();
-		AchievementIDs.fast.achievement = new Achievement(20108, "fast", -8, 10, ItemIDs.minecartVL10.item, AchievementIDs.electMotor.achievement).registerAchievement();
+		AchievementIDs.distilationTower.achievement = achievement("distilationTower", -10, 0, BlockIDs.distilActive.block, (Achievement) null);
+		AchievementIDs.dieselFuel.achievement = achievement("dieselFuel", -8, 2, ItemIDs.diesel.item, AchievementIDs.distilationTower.achievement);
+		AchievementIDs.plastic.achievement = achievement("plastic", -12, 2, ItemIDs.rawPlastic.item, AchievementIDs.distilationTower.achievement);
+		AchievementIDs.fineCopperWire.achievement = achievement("fineCopperWire", -12, 4, ItemIDs.copperWireFine.item, AchievementIDs.plastic.achievement);
+		AchievementIDs.electronicCircuit.achievement = achievement("electronicCircuit", -12, 6, ItemIDs.electronicCircuit.item, AchievementIDs.fineCopperWire.achievement);
+		AchievementIDs.generator.achievement = achievement("generator", -14, 8, ItemIDs.generator.item, AchievementIDs.electronicCircuit.achievement);
+		AchievementIDs.electMotor.achievement = achievement("electMotor", -10, 8, ItemIDs.electmotor.item, AchievementIDs.electronicCircuit.achievement);
+		AchievementIDs.tram.achievement = achievement("tram", -12, 10, ItemIDs.minecartTramWood.item, AchievementIDs.electMotor.achievement);
+		AchievementIDs.fast.achievement = achievement("fast", -8, 10, ItemIDs.minecartVL10.item, AchievementIDs.electMotor.achievement);
 
-		AchievementIDs.engineer.achievement = new Achievement(20128, "engineer", -2, -2, ItemIDs.overalls.item, (Achievement) null).setIndependent().registerAchievement();
+		AchievementIDs.engineer.achievement = achievement("engineer", -2, -2, ItemIDs.overalls.item, (Achievement) null);
 
-		AchievementIDs.assemblyTable.achievement = new Achievement(20132, "assemblyTable", 6, 0, BlockIDs.assemblyTableI.block, (Achievement) null).setIndependent().registerAchievement();
-		AchievementIDs.passenger.achievement = new Achievement(20102, "passenger", 5, 2, ItemIDs.minecartPassenger2.item, AchievementIDs.assemblyTable.achievement).registerAchievement();
-		AchievementIDs.freight.achievement = new Achievement(20103, "freight", 7, 2, ItemIDs.minecartChest.item, AchievementIDs.assemblyTable.achievement).registerAchievement();
-		AchievementIDs.liquid.achievement = new Achievement(20112, "liquid", 5, 4, ItemIDs.minecartWatertransp.item, AchievementIDs.assemblyTable.achievement).registerAchievement();
-		AchievementIDs.tender.achievement = new Achievement(20105, "tender", 7, 4, ItemIDs.minecartTender.item, AchievementIDs.assemblyTable.achievement).registerAchievement();
-		AchievementIDs.workCart.achievement = new Achievement(20110, "workCart", 5, 6, ItemIDs.minecartWork.item, AchievementIDs.assemblyTable.achievement).registerAchievement().setSpecial();
-		AchievementIDs.builder.achievement = new Achievement(20111, "builder", 7, 6, ItemIDs.minecartBuilder.item, AchievementIDs.assemblyTable.achievement).registerAchievement();
-		AchievementIDs.jukebox.achievement = new Achievement(20120, "jukebox", 5, 8, ItemIDs.minecartJukeBoxCart.item, AchievementIDs.assemblyTable.achievement).registerAchievement().setSpecial();
-		AchievementIDs.minetrain.achievement = new Achievement(20133, "minetrain", 7, 8, ItemIDs.minecartMineTrain.item, AchievementIDs.assemblyTable.achievement).registerAchievement();
-		AchievementIDs.cherepanov.achievement = new Achievement(20134, "cherepanov", 5, 10, ItemIDs.minecartLocoCherepanov.item, AchievementIDs.assemblyTable.achievement).registerAchievement();
-		AchievementIDs.mail.achievement = new Achievement(20135, "mail", 7, 10, ItemIDs.minecartMailWagon_DB.item, AchievementIDs.assemblyTable.achievement).registerAchievement();
-		AchievementIDs.stockCar.achievement = new Achievement(20136, "stockcar", 5, 12, ItemIDs.minecartStockCar.item, AchievementIDs.assemblyTable.achievement).registerAchievement();
-		AchievementIDs.caboose.achievement = new Achievement(20137, "caboose", 7, 12, ItemIDs.minecartCaboose.item, AchievementIDs.assemblyTable.achievement).registerAchievement();
-		AchievementIDs.flatCart.achievement = new Achievement(20138, "caboose", 5, 14, ItemIDs.minecartFlatCartRail_DB.item, AchievementIDs.assemblyTable.achievement).registerAchievement();
+		AchievementIDs.assemblyTable.achievement = achievement("assemblyTable", 6, 0, BlockIDs.assemblyTableI.block, (Achievement) null);
+		AchievementIDs.passenger.achievement = achievement("passenger", 5, 2, ItemIDs.minecartPassenger2.item, AchievementIDs.assemblyTable.achievement);
+		AchievementIDs.freight.achievement = achievement("freight", 7, 2, ItemIDs.minecartChest.item, AchievementIDs.assemblyTable.achievement);
+		AchievementIDs.liquid.achievement = achievement("liquid", 5, 4, ItemIDs.minecartWatertransp.item, AchievementIDs.assemblyTable.achievement);
+		AchievementIDs.tender.achievement = achievement("tender", 7, 4, ItemIDs.minecartTender.item, AchievementIDs.assemblyTable.achievement);
+		AchievementIDs.workCart.achievement = achievement("workCart", 5, 6, ItemIDs.minecartWork.item, AchievementIDs.assemblyTable.achievement).setSpecial();
+		AchievementIDs.builder.achievement = achievement("builder", 7, 6, ItemIDs.minecartBuilder.item, AchievementIDs.assemblyTable.achievement);
+		AchievementIDs.jukebox.achievement = achievement("jukebox", 5, 8, ItemIDs.minecartJukeBoxCart.item, AchievementIDs.assemblyTable.achievement).setSpecial();
+		AchievementIDs.minetrain.achievement = achievement("minetrain", 7, 8, ItemIDs.minecartMineTrain.item, AchievementIDs.assemblyTable.achievement);
+		AchievementIDs.cherepanov.achievement = achievement("cherepanov", 5, 10, ItemIDs.minecartLocoCherepanov.item, AchievementIDs.assemblyTable.achievement);
+		AchievementIDs.mail.achievement = achievement("mail", 7, 10, ItemIDs.minecartMailWagon_DB.item, AchievementIDs.assemblyTable.achievement);
+		AchievementIDs.stockCar.achievement = achievement("stockcar", 5, 12, ItemIDs.minecartStockCar.item, AchievementIDs.assemblyTable.achievement);
+		AchievementIDs.caboose.achievement = achievement("caboose", 7, 12, ItemIDs.minecartCaboose.item, AchievementIDs.assemblyTable.achievement);
+		AchievementIDs.flatCart.achievement = achievement("caboose", 5, 14, ItemIDs.minecartFlatCartRail_DB.item, AchievementIDs.assemblyTable.achievement);
 		//TODO put this: AchievementIDs.heavySteam.achievement  back once Heavy Steam is back
 		Achievement ach[] = new Achievement[] { AchievementIDs.steel.achievement, AchievementIDs.stake.achievement, AchievementIDs.dieselFuel.achievement, AchievementIDs.electMotor.achievement, AchievementIDs.dieselEngine.achievement, AchievementIDs.firebox.achievement, AchievementIDs.zeppelin.achievement, AchievementIDs.smallSteam.achievement, AchievementIDs.normalSteam.achievement, AchievementIDs.passenger.achievement, AchievementIDs.freight.achievement, AchievementIDs.liquid.achievement, AchievementIDs.tender.achievement, AchievementIDs.diesel.achievement, AchievementIDs.tram.achievement, AchievementIDs.fast.achievement, AchievementIDs.workCart.achievement, AchievementIDs.builder.achievement, AchievementIDs.jukebox.achievement, AchievementIDs.openHearth.achievement, AchievementIDs.engineer.achievement, AchievementIDs.distilationTower.achievement, AchievementIDs.plastic.achievement, AchievementIDs.fineCopperWire.achievement, AchievementIDs.electronicCircuit.achievement, AchievementIDs.generator.achievement, AchievementIDs.woodenParts.achievement, AchievementIDs.ironParts.achievement, AchievementIDs.steelParts.achievement, AchievementIDs.trainWB.achievement, AchievementIDs.assemblyTable.achievement, AchievementIDs.mail.achievement, AchievementIDs.minetrain.achievement, AchievementIDs.cherepanov.achievement, AchievementIDs.flatCart.achievement, AchievementIDs.stockCar.achievement, AchievementIDs.caboose.achievement };
 

--- a/src/main/java/src/train/common/core/handlers/FuelHandler.java
+++ b/src/main/java/src/train/common/core/handlers/FuelHandler.java
@@ -2,6 +2,8 @@ package src.train.common.core.handlers;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
+import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import src.train.common.core.plugins.PluginIndustrialCraft;
@@ -37,26 +39,39 @@ public class FuelHandler implements IFuelHandler {
 		if (it == null) {
 			return 0;
 		}
-		int var1 = it.getItem().itemID;
-		if (var1 < 256 && Block.blocksList[var1].blockMaterial == Material.wood)
+		Block block = Block.getBlockFromItem(it.getItem());
+		if (block != null && block.getMaterial() == Material.wood) {
 			return wood;
-		if (var1 == Item.stick.itemID)
+		}
+		int id = Item.getIdFromItem(it.getItem());
+		if (id == Item.getIdFromItem(Items.stick)) {
 			return stick;
-		if (var1 == Item.coal.itemID)
+		}
+		if (id == Item.getIdFromItem(Items.coal)) {
 			return coal;
-		if (var1 == Item.bucketLava.itemID)
+		}
+		if (id == Item.getIdFromItem(Items.lava_bucket)) {
 			return bucketLava;
-		if (var1 == Block.sapling.blockID)
+		}
+		if (id == Item.getIdFromItem(Item.getItemFromBlock(Blocks.sapling))) {
 			return sapling;
-		if (var1 == Item.blazeRod.itemID)
+		}
+		if (id == Item.getIdFromItem(Items.blaze_rod)) {
 			return blazeRod;
-		if (PluginIndustrialCraft.getItems().containsKey(PluginIndustrialCraft.getNames()[15]) && var1 == PluginIndustrialCraft.getItems().get(PluginIndustrialCraft.getNames()[15]).itemID)
+		}
+		// TODO: Hardcoding index to arbitrary array is worse than hardcoding the contents of that index...
+		String coalFuelName = PluginIndustrialCraft.getNames()[15];
+		if (PluginIndustrialCraft.getItems().containsKey(coalFuelName) &&
+				id == Item.getIdFromItem(PluginIndustrialCraft.getItems().get(coalFuelName).getItem())) {
 			return coalFuel;
-		if (PluginRailcraft.getItems().containsKey(PluginRailcraft.getNames()[1]) && var1 == PluginRailcraft.getItems().get(PluginRailcraft.getNames()[1]).itemID)
+		}
+		String cokeCoalName = PluginRailcraft.getNames()[1];
+		if (PluginRailcraft.getItems().containsKey(cokeCoalName) &&
+				id == Item.getIdFromItem(PluginRailcraft.getItems().get(cokeCoalName).getItem())) {
 			return cokeCoal;
+		}
 
-		int ret = GameRegistry.getFuelValue(it);
-		return ret;
+		return GameRegistry.getFuelValue(it);
 	}
 
 	/**
@@ -66,8 +81,7 @@ public class FuelHandler implements IFuelHandler {
 	 */
 	@Override
 	public int getBurnTime(ItemStack fuel) {
-		int var1 = fuel.itemID;
-		if(var1 == BlockIDs.oreTC.blockID && (fuel.getItemDamage()==1 || fuel.getItemDamage()==2)){
+		if(Item.getIdFromItem(fuel.getItem()) == Item.getIdFromItem(Item.getItemFromBlock(BlockIDs.oreTC.block)) && (fuel.getItemDamage() == 1 || fuel.getItemDamage() == 2)){
 			return 2400;
 		}
 		return 0;

--- a/src/main/java/src/train/common/core/handlers/ItemHandler.java
+++ b/src/main/java/src/train/common/core/handlers/ItemHandler.java
@@ -12,9 +12,11 @@ import java.util.ArrayList;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockRailBase;
 import net.minecraft.entity.Entity;
+import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
+import src.train.common.Traincraft;
 import src.train.common.api.DieselTrain;
 import src.train.common.api.ElectricTrain;
 import src.train.common.api.Freight;
@@ -48,25 +50,20 @@ import src.train.common.items.ItemTCRail;
 public class ItemHandler {
 
 	public static boolean handleItems(Entity entity, ItemStack itemstack) {
-		if(itemstack!= null) {
-    		if(entity instanceof Freight) {
-    			return handleFreight(entity, itemstack);
-    		}
-    		else if(entity instanceof DieselTrain) {
-    			return handleDiesel(entity, itemstack);
-    		}
-    		else if(entity instanceof ElectricTrain) {
-    			return handleElectric(entity, itemstack);
-    		}
-            else if(entity instanceof SteamTrain) {
-            	return handleSteam(entity, itemstack);
-            }
-            else if(entity instanceof Tender) {
-            	return handleTender(entity, itemstack);
-            }
-            else {
-            	return handleOther(entity, itemstack);
-            }
+		if (itemstack != null) {
+			if (entity instanceof Freight) {
+				return handleFreight(entity, itemstack);
+			} else if (entity instanceof DieselTrain) {
+				return handleDiesel(entity, itemstack);
+			} else if (entity instanceof ElectricTrain) {
+				return handleElectric(entity, itemstack);
+			} else if (entity instanceof SteamTrain) {
+				return handleSteam(entity, itemstack);
+			} else if (entity instanceof Tender) {
+				return handleTender(entity, itemstack);
+			} else {
+				return handleOther(entity, itemstack);
+			}
 		}
 		return false;
 	}
@@ -92,186 +89,157 @@ public class ItemHandler {
 	}
 
 	public static boolean handleFreight(Entity entity, ItemStack itemstack) {
-		//System.out.println(entity.getEntityName());
-		
-		Block block = null;
-		if (itemstack.itemID < Block.blocksList.length/* && itemstack.itemID < 256 && itemstack.itemID > 421*/) {
-			block = Block.blocksList[itemstack.itemID];
+		Block block = Block.getBlockFromItem(itemstack.getItem());
+		if (block == null) {
+			return false;
 		}
-		
-		if(entity instanceof EntityBoxCartUS) {
+		if (entity instanceof EntityBoxCartUS) {
 			return true;
 		}
-		else if(entity instanceof EntityFlatCarLogs_DB) {
-			if(block != null) {
-				return isDict("logWood", itemstack);
+		if (entity instanceof EntityFlatCarLogs_DB) {
+			return isDict("logWood", itemstack);
+		}
+		if (entity instanceof EntityFlatCarRails_DB) {
+			if (block instanceof BlockRailBase) {
+				return true;
 			}
-			return false;
+			return itemstack.getItem() instanceof ItemTCRail;
 		}
-		else if(entity instanceof EntityFlatCarRails_DB) {
-			if(block != null) {
-        		if(Block.blocksList[itemstack.itemID] instanceof BlockRailBase) {
-        			return true;
-        		}
-        	}
-			if(itemstack!=null && itemstack.getItem() instanceof ItemTCRail)return true;
-			
-        	return false;
+		if (entity instanceof EntityFlatCartWoodUS) {
+			return isDict("plankWood", itemstack);
 		}
-		else if(entity instanceof EntityFlatCartWoodUS) {
-			if(block != null) {
-				return isDict("plankWood", itemstack);
-			}
-			return false;	
-		}
-		else if(entity instanceof EntityFreightCart) {
+		if (entity instanceof EntityFreightCart) {
 			return true;
 		}
-        else if(entity instanceof EntityFreightCart2) {
-        	return true;		
-        }
-        else if(entity instanceof EntityFreightCartSmall) {
-        	return true;
-        }
-        else if(entity instanceof EntityFreightCartUS) {
-        	if(block != null && !woodStuff(itemstack)) {
-        		if(block instanceof Block) {
-        			return true;
-        		}
-        	}
-        	return false;
-        }
-        else if(entity instanceof EntityFreightCenterbeam_Empty) {
-        	return true;
-        }
-        else if(entity instanceof EntityFreightCenterbeam_Wood_1) {
-        	if(block != null) {
-        		return woodStuff(itemstack);
-			}
-			return false;
-        }
-        else if(entity instanceof EntityFreightCenterbeam_Wood_2) {
-        	if(block != null) {
-				return woodStuff(itemstack);
-			}
-			return false;
-        }
-        else if(entity instanceof EntityFreightClosed) {
-        	if(block != null && !woodStuff(itemstack)) {
-        		if(block instanceof Block) {
-        			return true;
-        		}
-        	}
-        	return false;
-        }
-        else if(entity instanceof EntityFreightGondola_DB) {
-        	if(block != null && !woodStuff(itemstack)) {
-        		if(block instanceof Block) {
-        			return true;
-        		}
-        	}
-        	return false;
+		if (entity instanceof EntityFreightCart2) {
+			return true;
 		}
-        else if(entity instanceof EntityFreightGrain) {
-        	if(itemstack.getItem().itemID == Item.wheat.itemID || itemstack.getItem().itemID == Item.seeds.itemID || itemstack.getItem().itemID == Item.melonSeeds.itemID || itemstack.getItem().itemID == Item.pumpkinSeeds.itemID) {
-        		return true;
-        	}
-        	if(cropStuff(itemstack)) {
-        		return true;
-        	}
-        	return false;		
-        }
-        else if(entity instanceof EntityFreightHopperUS) {
-        	if(block != null) {
-        		if(block instanceof Block && !woodStuff(itemstack)) {
-        			return true;
-        		}
-        		else {
-        			return false;
-        		}
-        	}
-        	else {
-        		return false;
-        	}
-        }
-        else if(entity instanceof EntityFreightMinetrain) {
-        	if(block != null) {
-        		if(block.isOpaqueCube()) {
-        			return true;
-        		}
-        		return false;
-        	}
-        	else {
-        		if(itemstack.getItem().isDamaged(itemstack)) {
-        			return false;
-        		}
-        	}
-        }
-        else if(entity instanceof EntityFreightOpen2) {
-        	if(block != null && !woodStuff(itemstack)) {
-        		if(block instanceof Block) {
-        			return true;
-        		}
-        	}
-        	return false;
-        }
-        else if(entity instanceof EntityFreightTrailer) {
-        	return true;
-        }
-        else if(entity instanceof EntityFreightWagenDB) {
-        	return true;
-        }
-        else if(entity instanceof EntityFreightWellcar) {
-        	return true;
-        }
-        else if(entity instanceof EntityFreightWood) {
-        	if(block != null) {
-        		return isDict("logWood", itemstack);
+		if (entity instanceof EntityFreightCartSmall) {
+			return true;
+		}
+		if (entity instanceof EntityFreightCartUS) {
+			if (!woodStuff(itemstack)) {
+				// TODO: Why there is this check? Did they though it could be
+				// item?
+				if (block instanceof Block) {
+					return true;
+				}
 			}
 			return false;
 		}
-        else if(entity instanceof EntityFreightWood2) {
-        	if(block != null) {
-				return isDict("logWood", itemstack);
+		if (entity instanceof EntityFreightCenterbeam_Empty) {
+			return true;
+		}
+		if (entity instanceof EntityFreightCenterbeam_Wood_1) {
+			return woodStuff(itemstack);
+		}
+		if (entity instanceof EntityFreightCenterbeam_Wood_2) {
+			return woodStuff(itemstack);
+		}
+		if (entity instanceof EntityFreightClosed) {
+			if (!woodStuff(itemstack)) {
+				// TODO: Why there is this check? Did they though it could be
+				// item?
+				if (block instanceof Block) {
+					return true;
+				}
 			}
-			return false;		
-        }
-        else if(entity instanceof EntityFreightOpenWagon) {
-        	if(block != null) {
-        		if(block instanceof Block && !woodStuff(itemstack)) {
-        			System.out.println(block.getLocalizedName());
-        			return true;
-        		}
-        	}
-        	return false;
-        }
+			return false;
+		}
+		if (entity instanceof EntityFreightGondola_DB) {
+			if (!woodStuff(itemstack)) {
+				// TODO: Why there is this check? Did they though it could be
+				// item?
+				if (block instanceof Block) {
+					return true;
+				}
+			}
+			return false;
+		}
+		if (entity instanceof EntityFreightGrain) {
+			int id = Item.getIdFromItem(itemstack.getItem());
+			if (id == Item.getIdFromItem(Items.wheat)
+					|| id == Item.getIdFromItem(Items.wheat_seeds)
+					|| id == Item.getIdFromItem(Items.melon_seeds)
+					|| id == Item.getIdFromItem(Items.pumpkin_seeds)) {
+				return true;
+			}
+			return cropStuff(itemstack);
+		}
+		if (entity instanceof EntityFreightHopperUS) {
+			// TODO: Why there is this check? Did they though it could be item?
+			return block instanceof Block && !woodStuff(itemstack);
+		}
+		if (entity instanceof EntityFreightMinetrain) {
+			if (block != null) {
+				return block.isOpaqueCube();
+			} else {
+				// TODO: Why there is this? NOTE: This wouldn't have been
+				// deadcode because the blocks nullness wasn't checked
+				if (itemstack.getItem().isDamaged(itemstack)) {
+					return false;
+				}
+			}
+		}
+		if (entity instanceof EntityFreightOpen2) {
+			if (!woodStuff(itemstack)) {
+				// TODO: Why there is this check? Did they though it could be
+				// item?
+				if (block instanceof Block) {
+					return true;
+				}
+			}
+			return false;
+		}
+		if (entity instanceof EntityFreightTrailer) {
+			return true;
+		}
+		if (entity instanceof EntityFreightWagenDB) {
+			return true;
+		}
+		if (entity instanceof EntityFreightWellcar) {
+			return true;
+		}
+		if (entity instanceof EntityFreightWood) {
+			return isDict("logWood", itemstack);
+		}
+		if (entity instanceof EntityFreightWood2) {
+			return isDict("logWood", itemstack);
+		}
+		if (entity instanceof EntityFreightOpenWagon) {
+			// TODO: Why there is this check? Did they though it could be item?
+			if (block instanceof Block && !woodStuff(itemstack)) {
+				return true;
+			}
+		}
 		return false;
 	}
-	
+
 	private static boolean cropStuff(ItemStack itemstack) {
-		String[] names = new String[] {"cropCorn", "cropHops", "cropRice", "seedCorn"};
-		for (int i = 0; i < names.length; i++) {
-			if(isDict(names[i], itemstack)) {
+		String[] names = new String[] { "cropCorn", "cropHops", "cropRice",
+				"seedCorn" };
+		for (String name: names) {
+			if (isDict(name, itemstack)) {
 				return true;
 			}
 		}
 		return false;
 	}
-	
+
 	private static boolean woodStuff(ItemStack itemstack) {
-		String[] names = new String[] {"logWood", "plankWood", "slabWood", "stickWood", "stairWood"};
-		for (int i = 0; i < names.length; i++) {
-			if(isDict(names[i], itemstack)) {
+		String[] names = new String[] { "logWood", "plankWood", "slabWood",
+				"stickWood", "stairWood" };
+		for (String name: names) {
+			if (isDict(name, itemstack)) {
 				return true;
 			}
 		}
 		return false;
 	}
-	
+
 	private static boolean isDict(String name, ItemStack itemstack) {
-		ArrayList<ItemStack> items = OreDictionary.getOres(name);
-		for (int i = 0; i < items.size(); i++) {
-			if(itemstack.getItem().itemID == items.get(i).itemID) {
+		for (ItemStack item : OreDictionary.getOres(name)) {
+			if (itemstack.isItemEqual(item)) {
 				return true;
 			}
 		}

--- a/src/main/java/src/train/common/core/handlers/RecipeHandler.java
+++ b/src/main/java/src/train/common/core/handlers/RecipeHandler.java
@@ -10,6 +10,8 @@ package src.train.common.core.handlers;
 import java.util.ArrayList;
 
 import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.FurnaceRecipes;
@@ -25,40 +27,40 @@ public class RecipeHandler {
 	public static void initBlockRecipes() {
 		TrainCraftingManager.instance.getRecipeList().add(new RecipesArmorDyes());
 		/* Assembly tables */
-		GameRegistry.addRecipe(new ItemStack(BlockIDs.assemblyTableI.block, 1), new Object[] { "IPI", "S S", "SPS", Character.valueOf('I'), Item.ingotIron, Character.valueOf('P'), Block.pistonBase, Character.valueOf('S'), Block.stone });
-		GameRegistry.addRecipe(new ItemStack(BlockIDs.assemblyTableII.block, 1), new Object[] { "GPG", "O O", "OPO", Character.valueOf('G'), Item.ingotGold, Character.valueOf('P'), Block.pistonBase, Character.valueOf('O'), Block.obsidian });
-		GameRegistry.addRecipe(new ItemStack(BlockIDs.assemblyTableIII.block, 1), new Object[] { "GPG", "DLD", "OPO", Character.valueOf('G'), Item.ingotGold, Character.valueOf('P'), Block.pistonBase, Character.valueOf('D'), Item.diamond, Character.valueOf('L'), Block.glowStone, Character.valueOf('O'), Block.obsidian });
-		addDictRecipe(new ItemStack(BlockIDs.trainWorkbench.block, 1), new Object[] { "###", "IFI", "###", Character.valueOf('#'), "plankWood", Character.valueOf('F'), Block.furnaceIdle, Character.valueOf('I'), Item.ingotIron });
+		GameRegistry.addRecipe(new ItemStack(BlockIDs.assemblyTableI.block, 1), new Object[] { "IPI", "S S", "SPS", Character.valueOf('I'), Items.iron_ingot, Character.valueOf('P'), Blocks.piston, Character.valueOf('S'), Blocks.stone });
+		GameRegistry.addRecipe(new ItemStack(BlockIDs.assemblyTableII.block, 1), new Object[] { "GPG", "O O", "OPO", Character.valueOf('G'), Items.gold_ingot, Character.valueOf('P'), Blocks.piston, Character.valueOf('O'), Blocks.obsidian });
+		GameRegistry.addRecipe(new ItemStack(BlockIDs.assemblyTableIII.block, 1), new Object[] { "GPG", "DLD", "OPO", Character.valueOf('G'), Items.gold_ingot, Character.valueOf('P'), Blocks.piston, Character.valueOf('D'), Items.diamond, Character.valueOf('L'), Blocks.glowstone, Character.valueOf('O'), Blocks.obsidian });
+		addDictRecipe(new ItemStack(BlockIDs.trainWorkbench.block, 1), new Object[] { "###", "IFI", "###", Character.valueOf('#'), "plankWood", Character.valueOf('F'), Blocks.furnace, Character.valueOf('I'), Items.iron_ingot });
 		addDictRecipe(new ItemStack(BlockIDs.distilIdle.block, 1), new Object[] { "###", "#F#", "###", Character.valueOf('#'), "ingotSteel", Character.valueOf('F'), ItemIDs.firebox.item });
 
 		/* Open Hearth Furnace */
-		GameRegistry.addRecipe(new ItemStack(BlockIDs.openFurnaceIdle.block, 1), new Object[] { "#L#", "#B#", "#I#", Character.valueOf('#'), Block.netherBrick, Character.valueOf('L'), Item.bucketLava, Character.valueOf('B'), Item.bucketEmpty, Character.valueOf('I'), Block.blockIron });
+		GameRegistry.addRecipe(new ItemStack(BlockIDs.openFurnaceIdle.block, 1), new Object[] { "#L#", "#B#", "#I#", Character.valueOf('#'), Blocks.nether_brick, Character.valueOf('L'), Items.lava_bucket, Character.valueOf('B'), Items.bucket, Character.valueOf('I'), Blocks.iron_block });
 
 		/* Lantern */
-		GameRegistry.addRecipe(new ItemStack(BlockIDs.lantern.block, 4), new Object[] { "III", "PTP", "III", Character.valueOf('I'), Item.ingotIron, Character.valueOf('P'), Block.thinGlass, Character.valueOf('T'),Block.torchWood });
+		GameRegistry.addRecipe(new ItemStack(BlockIDs.lantern.block, 4), new Object[] { "III", "PTP", "III", Character.valueOf('I'), Items.iron_ingot, Character.valueOf('P'), Blocks.glass_pane, Character.valueOf('T'),Blocks.torch });
 		
 		/* Clothes */
-		GameRegistry.addRecipe(new ItemStack(ItemIDs.overalls.item, 1), new Object[] { " # ", "X$X", "X$X", Character.valueOf('X'), new ItemStack(Item.dyePowder, 1, 4), Character.valueOf('$'), Item.legsLeather, Character.valueOf('#'), new ItemStack(Item.dyePowder, 1, 1) });
-		GameRegistry.addRecipe(new ItemStack(ItemIDs.jacket.item, 1), new Object[] { "X X", "X$X", "X#X", Character.valueOf('X'), new ItemStack(Item.dyePowder, 1, 14), Character.valueOf('$'), Item.plateLeather, Character.valueOf('#'), Item.silk });
-		GameRegistry.addRecipe(new ItemStack(ItemIDs.hat.item, 1), new Object[] { " X ", "X$X", "#X#", Character.valueOf('X'), new ItemStack(Item.dyePowder, 1, 4), Character.valueOf('$'), Item.helmetLeather, Character.valueOf('#'), Item.silk });
+		GameRegistry.addRecipe(new ItemStack(ItemIDs.overalls.item, 1), new Object[] { " # ", "X$X", "X$X", Character.valueOf('X'), new ItemStack(Items.dye, 1, 4), Character.valueOf('$'), Items.leather_leggings, Character.valueOf('#'), new ItemStack(Items.dye, 1, 1) });
+		GameRegistry.addRecipe(new ItemStack(ItemIDs.jacket.item, 1), new Object[] { "X X", "X$X", "X#X", Character.valueOf('X'), new ItemStack(Items.dye, 1, 14), Character.valueOf('$'), Items.leather_chestplate, Character.valueOf('#'), Items.string });
+		GameRegistry.addRecipe(new ItemStack(ItemIDs.hat.item, 1), new Object[] { " X ", "X$X", "#X#", Character.valueOf('X'), new ItemStack(Items.dye, 1, 4), Character.valueOf('$'), Items.leather_helmet, Character.valueOf('#'), Items.string });
 
 		/* Driver Clothes*/
-		GameRegistry.addRecipe(new ItemStack(ItemIDs.pants_driver_paintable.item, 1), new Object[] { "XXX", "XLX", "X$X", Character.valueOf('L'), Item.legsLeather,Character.valueOf('$'), new ItemStack(Item.dyePowder, 1, 4), Character.valueOf('X'), Item.silk});
-		GameRegistry.addRecipe(new ItemStack(ItemIDs.jacket_driver_paintable.item, 1), new Object[] { "X X", "XRX", "XPX", Character.valueOf('X'), new ItemStack(Item.dyePowder, 1, 4), Character.valueOf('P'), Item.plateLeather,Character.valueOf('R'),  new ItemStack(Item.dyePowder, 1, 1) });
-		GameRegistry.addRecipe(new ItemStack(ItemIDs.hat_driver_paintable.item, 1), new Object[] {"#$#", "# #", Character.valueOf('$'), new ItemStack(Item.dyePowder, 1, 4), Character.valueOf('#'), Item.silk });
+		GameRegistry.addRecipe(new ItemStack(ItemIDs.pants_driver_paintable.item, 1), new Object[] { "XXX", "XLX", "X$X", Character.valueOf('L'), Items.leather_leggings,Character.valueOf('$'), new ItemStack(Items.dye, 1, 4), Character.valueOf('X'), Items.string});
+		GameRegistry.addRecipe(new ItemStack(ItemIDs.jacket_driver_paintable.item, 1), new Object[] { "X X", "XRX", "XPX", Character.valueOf('X'), new ItemStack(Items.dye, 1, 4), Character.valueOf('P'), Items.leather_chestplate,Character.valueOf('R'),  new ItemStack(Items.dye, 1, 1) });
+		GameRegistry.addRecipe(new ItemStack(ItemIDs.hat_driver_paintable.item, 1), new Object[] {"#$#", "# #", Character.valueOf('$'), new ItemStack(Items.dye, 1, 4), Character.valueOf('#'), Items.string });
 		
 		/* Ticket Man Clothes */
-		GameRegistry.addRecipe(new ItemStack(ItemIDs.pants_ticketMan_paintable.item, 1), new Object[] { "XXX", "XLX", "X$X", Character.valueOf('L'), Item.legsLeather,Character.valueOf('$'), new ItemStack(Item.dyePowder, 1, 8), Character.valueOf('X'), Item.silk});
-		GameRegistry.addRecipe(new ItemStack(ItemIDs.jacket_ticketMan_paintable.item, 1), new Object[] { "X X", "XPX", "X#X", Character.valueOf('P'), Item.plateLeather, Character.valueOf('#'), new ItemStack(Item.dyePowder, 1, 4), Character.valueOf('X'), Item.silk});
-		GameRegistry.addRecipe(new ItemStack(ItemIDs.hat_ticketMan_paintable.item, 1), new Object[] {"#$#", "# #", Character.valueOf('$'), new ItemStack(Item.dyePowder, 1, 0), Character.valueOf('#'), Item.silk });
+		GameRegistry.addRecipe(new ItemStack(ItemIDs.pants_ticketMan_paintable.item, 1), new Object[] { "XXX", "XLX", "X$X", Character.valueOf('L'), Items.leather_leggings,Character.valueOf('$'), new ItemStack(Items.dye, 1, 8), Character.valueOf('X'), Items.string});
+		GameRegistry.addRecipe(new ItemStack(ItemIDs.jacket_ticketMan_paintable.item, 1), new Object[] { "X X", "XPX", "X#X", Character.valueOf('P'), Items.leather_chestplate, Character.valueOf('#'), new ItemStack(Items.dye, 1, 4), Character.valueOf('X'), Items.string});
+		GameRegistry.addRecipe(new ItemStack(ItemIDs.hat_ticketMan_paintable.item, 1), new Object[] {"#$#", "# #", Character.valueOf('$'), new ItemStack(Items.dye, 1, 0), Character.valueOf('#'), Items.string });
 		
 		/* Recipe book */
-		GameRegistry.addRecipe(new ItemStack(ItemIDs.recipeBook.item, 1), new Object[] { "TTT", "TBT", "TTT", Character.valueOf('T'), Block.rail, Character.valueOf('B'), Item.book });
+		GameRegistry.addRecipe(new ItemStack(ItemIDs.recipeBook.item, 1), new Object[] { "TTT", "TBT", "TTT", Character.valueOf('T'), Blocks.rail, Character.valueOf('B'), Items.book });
 
 		/*Buffer*/
-		addDictRecipe(new ItemStack(BlockIDs.stopper.block, 1), new Object[] { "WWW", "I I", "RRR", Character.valueOf('W'), "plankWood", Character.valueOf('R'), Block.rail, Character.valueOf('I'), Item.ingotIron});
+		addDictRecipe(new ItemStack(BlockIDs.stopper.block, 1), new Object[] { "WWW", "I I", "RRR", Character.valueOf('W'), "plankWood", Character.valueOf('R'), Blocks.rail, Character.valueOf('I'), Items.iron_ingot});
 		
-		GameRegistry.addRecipe(new ItemStack(BlockIDs.oreTC.block, 1,3), new Object[] { "GXG", Character.valueOf('G'), Block.gravel, Character.valueOf('X'), Item.clay});
+		GameRegistry.addRecipe(new ItemStack(BlockIDs.oreTC.block, 1,3), new Object[] { "GXG", Character.valueOf('G'), Blocks.gravel, Character.valueOf('X'), Items.clay_ball});
 		
 	}
 
@@ -70,41 +72,41 @@ public class RecipeHandler {
 		ArrayList<ItemStack> planks = OreDictionary.getOres("plankWood");
 		if (planks != null && planks.size() >= 0) {
 			for (ItemStack plank : planks) {
-				TrainCraftingManager.instance.addRecipe(new ItemStack(BlockIDs.trainWorkbench.block, 1), new Object[] { "###", "IFI", "###", Character.valueOf('#'), plank, Character.valueOf('F'), Block.furnaceIdle, Character.valueOf('I'), Item.ingotIron });
+				TrainCraftingManager.instance.addRecipe(new ItemStack(BlockIDs.trainWorkbench.block, 1), new Object[] { "###", "IFI", "###", Character.valueOf('#'), plank, Character.valueOf('F'), Blocks.furnace, Character.valueOf('I'), Items.iron_ingot });
 			}
 		}
 		
 		/* Recipe book */
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.recipeBook.item, 1), new Object[] { "TTT", "TBT", "TTT", Character.valueOf('T'), Block.rail, Character.valueOf('B'), Item.book });
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.recipeBook.item, 1), new Object[] { "TTT", "TBT", "TTT", Character.valueOf('T'), Blocks.rail, Character.valueOf('B'), Items.book });
 
 		/* Chunk Loader Activator */
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.chunkLoaderActivator.item, 1), new Object[] { "  P", " S ", "S  ", Character.valueOf('S'), Item.blazeRod, Character.valueOf('P'), Item.enderPearl });
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.chunkLoaderActivator.item, 1), new Object[] { "  P", " S ", "S  ", Character.valueOf('S'), Items.blaze_rod, Character.valueOf('P'), Items.ender_pearl });
 
 		/* Assembly tables */
-		TrainCraftingManager.instance.addRecipe(new ItemStack(BlockIDs.assemblyTableI.block, 1), new Object[] { "IPI", "S S", "SPS", Character.valueOf('I'), Item.ingotIron, Character.valueOf('P'), Block.pistonBase, Character.valueOf('S'), Block.stone });
-		TrainCraftingManager.instance.addRecipe(new ItemStack(BlockIDs.assemblyTableII.block, 1), new Object[] { "GPG", "O O", "OPO", Character.valueOf('G'), Item.ingotGold, Character.valueOf('P'), Block.pistonBase, Character.valueOf('O'), Block.obsidian });
-		TrainCraftingManager.instance.addRecipe(new ItemStack(BlockIDs.assemblyTableIII.block, 1), new Object[] { "GPG", "DLD", "OPO", Character.valueOf('G'), Item.ingotGold, Character.valueOf('P'), Block.pistonBase, Character.valueOf('D'), Item.diamond, Character.valueOf('L'), Block.glowStone, Character.valueOf('O'), Block.obsidian });
+		TrainCraftingManager.instance.addRecipe(new ItemStack(BlockIDs.assemblyTableI.block, 1), new Object[] { "IPI", "S S", "SPS", Character.valueOf('I'), Items.iron_ingot, Character.valueOf('P'), Blocks.piston, Character.valueOf('S'), Blocks.stone });
+		TrainCraftingManager.instance.addRecipe(new ItemStack(BlockIDs.assemblyTableII.block, 1), new Object[] { "GPG", "O O", "OPO", Character.valueOf('G'), Items.gold_ingot, Character.valueOf('P'), Blocks.piston, Character.valueOf('O'), Blocks.obsidian });
+		TrainCraftingManager.instance.addRecipe(new ItemStack(BlockIDs.assemblyTableIII.block, 1), new Object[] { "GPG", "DLD", "OPO", Character.valueOf('G'), Items.gold_ingot, Character.valueOf('P'), Blocks.piston, Character.valueOf('D'), Items.diamond, Character.valueOf('L'), Blocks.glowstone, Character.valueOf('O'), Blocks.obsidian });
 
 		/* Open Hearth Furnace */
-		TrainCraftingManager.instance.addRecipe(new ItemStack(BlockIDs.openFurnaceIdle.block, 1), new Object[] { "#L#", "#B#", "#I#", Character.valueOf('#'), Block.netherBrick, Character.valueOf('L'), Item.bucketLava, Character.valueOf('B'), Item.bucketEmpty, Character.valueOf('I'), Block.blockIron });
+		TrainCraftingManager.instance.addRecipe(new ItemStack(BlockIDs.openFurnaceIdle.block, 1), new Object[] { "#L#", "#B#", "#I#", Character.valueOf('#'), Blocks.nether_brick, Character.valueOf('L'), Items.lava_bucket, Character.valueOf('B'), Items.bucket, Character.valueOf('I'), Blocks.iron_block });
 
 		/* Lantern */
-		TrainCraftingManager.instance.addRecipe(new ItemStack(BlockIDs.lantern.block, 4), new Object[] { "III", "PTP", "III", Character.valueOf('I'), Item.ingotIron, Character.valueOf('P'), Block.thinGlass, Character.valueOf('T'),Block.torchWood });
+		TrainCraftingManager.instance.addRecipe(new ItemStack(BlockIDs.lantern.block, 4), new Object[] { "III", "PTP", "III", Character.valueOf('I'), Items.iron_ingot, Character.valueOf('P'), Blocks.glass_pane, Character.valueOf('T'),Blocks.torch });
 	
 		/* Clothes */
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.overalls.item, 1), new Object[] { " # ", "X$X", "X X", Character.valueOf('X'), new ItemStack(Item.dyePowder, 1, 4), Character.valueOf('$'), Item.legsLeather, Character.valueOf('#'), new ItemStack(Item.dyePowder, 1, 1) });
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.jacket.item, 1), new Object[] { "X X", "X$X", "X#X", Character.valueOf('X'), new ItemStack(Item.dyePowder, 1, 14), Character.valueOf('$'), Item.plateLeather, Character.valueOf('#'), Item.silk });
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.hat.item, 1), new Object[] { " X ", "X$X", "#X#", Character.valueOf('X'), new ItemStack(Item.dyePowder, 1, 4), Character.valueOf('$'), Item.helmetLeather, Character.valueOf('#'), Item.silk });
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.overalls.item, 1), new Object[] { " # ", "X$X", "X X", Character.valueOf('X'), new ItemStack(Items.dye, 1, 4), Character.valueOf('$'), Items.leather_leggings, Character.valueOf('#'), new ItemStack(Items.dye, 1, 1) });
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.jacket.item, 1), new Object[] { "X X", "X$X", "X#X", Character.valueOf('X'), new ItemStack(Items.dye, 1, 14), Character.valueOf('$'), Items.leather_chestplate, Character.valueOf('#'), Items.string });
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.hat.item, 1), new Object[] { " X ", "X$X", "#X#", Character.valueOf('X'), new ItemStack(Items.dye, 1, 4), Character.valueOf('$'), Items.leather_helmet, Character.valueOf('#'), Items.string });
 		
 		/* Driver Clothes*/
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.pants_driver_paintable.item, 1), new Object[] { "XXX", "XLX", "X$X", Character.valueOf('L'), Item.legsLeather,Character.valueOf('$'), new ItemStack(Item.dyePowder, 1, 4), Character.valueOf('X'), Item.silk});
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.jacket_driver_paintable.item, 1), new Object[] { "X X", "XRX", "XPX", Character.valueOf('X'), new ItemStack(Item.dyePowder, 1, 4), Character.valueOf('P'), Item.plateLeather,Character.valueOf('R'),  new ItemStack(Item.dyePowder, 1, 1) });
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.hat_driver_paintable.item, 1), new Object[] {"#$#", "# #", Character.valueOf('$'), new ItemStack(Item.dyePowder, 1, 4), Character.valueOf('#'), Item.silk });
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.pants_driver_paintable.item, 1), new Object[] { "XXX", "XLX", "X$X", Character.valueOf('L'), Items.leather_leggings,Character.valueOf('$'), new ItemStack(Items.dye, 1, 4), Character.valueOf('X'), Items.string});
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.jacket_driver_paintable.item, 1), new Object[] { "X X", "XRX", "XPX", Character.valueOf('X'), new ItemStack(Items.dye, 1, 4), Character.valueOf('P'), Items.leather_chestplate,Character.valueOf('R'),  new ItemStack(Items.dye, 1, 1) });
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.hat_driver_paintable.item, 1), new Object[] {"#$#", "# #", Character.valueOf('$'), new ItemStack(Items.dye, 1, 4), Character.valueOf('#'), Items.string });
 		
 		/* Ticket Man Clothes */
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.pants_ticketMan_paintable.item, 1), new Object[] { "XXX", "XLX", "X$X", Character.valueOf('L'), Item.legsLeather,Character.valueOf('$'), new ItemStack(Item.dyePowder, 1, 8), Character.valueOf('X'), Item.silk});
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.jacket_ticketMan_paintable.item, 1), new Object[] { "X X", "XPX", "X#X", Character.valueOf('P'), Item.plateLeather, Character.valueOf('#'), new ItemStack(Item.dyePowder, 1, 4), Character.valueOf('X'), Item.silk});
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.hat_ticketMan_paintable.item, 1), new Object[] {"#$#", "# #", Character.valueOf('$'), new ItemStack(Item.dyePowder, 1, 0), Character.valueOf('#'), Item.silk });
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.pants_ticketMan_paintable.item, 1), new Object[] { "XXX", "XLX", "X$X", Character.valueOf('L'), Items.leather_leggings,Character.valueOf('$'), new ItemStack(Items.dye, 1, 8), Character.valueOf('X'), Items.string});
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.jacket_ticketMan_paintable.item, 1), new Object[] { "X X", "XPX", "X#X", Character.valueOf('P'), Items.leather_chestplate, Character.valueOf('#'), new ItemStack(Items.dye, 1, 4), Character.valueOf('X'), Items.string});
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.hat_ticketMan_paintable.item, 1), new Object[] {"#$#", "# #", Character.valueOf('$'), new ItemStack(Items.dye, 1, 0), Character.valueOf('#'), Items.string });
 		
 		
 		ArrayList<ItemStack> plastics = OreDictionary.getOres("dustPlastic");
@@ -114,9 +116,9 @@ public class RecipeHandler {
 				/* Empty canister */
 				TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.emptyCanister.item, 4), new Object[] { "PPP", "P P", "PPP", Character.valueOf('P'), plastic});
 				/* Electronic circuit */
-				TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.electronicCircuit.item, 1), new Object[] { "XXX", "RPR", "XXX", Character.valueOf('X'), ItemIDs.copperWireFine.item, Character.valueOf('P'), plastic, Character.valueOf('R'), Item.redstone });
+				TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.electronicCircuit.item, 1), new Object[] { "XXX", "RPR", "XXX", Character.valueOf('X'), ItemIDs.copperWireFine.item, Character.valueOf('P'), plastic, Character.valueOf('R'), Items.redstone });
 				/* Composite Material*/
-				TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.reinforcedPlastic.item, 16), new Object[] { "LPL", "PLP", "GPG", Character.valueOf('G'), Block.thinGlass, Character.valueOf('P'), ItemIDs.graphite.item, Character.valueOf('L'), plastic});
+				TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.reinforcedPlastic.item, 16), new Object[] { "LPL", "PLP", "GPG", Character.valueOf('G'), Blocks.glass_pane, Character.valueOf('P'), ItemIDs.graphite.item, Character.valueOf('L'), plastic});
 				
 				if (copper != null && copper.size() >= 0) {
 					for (ItemStack copp : copper) {
@@ -127,42 +129,42 @@ public class RecipeHandler {
 		}
 		
 		/* Composite Suit */
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.boots_suit_paintable.item, 1), new Object[] {" D ","X X", "XFX", Character.valueOf('F'), Item.feather, Character.valueOf('D'), Item.diamond, Character.valueOf('X'), ItemIDs.reinforcedPlates.item});
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.pants_suit_paintable.item, 1), new Object[] { "XDX", "X$X", "X X", Character.valueOf('$'), Item.fireballCharge, Character.valueOf('X'), ItemIDs.reinforcedPlates.item,Character.valueOf('D'), Item.diamond});
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.jacket_suit_paintable.item, 1), new Object[] { "X X", "XDX", "XAX", Character.valueOf('A'), Item.appleGold, Character.valueOf('X'), ItemIDs.reinforcedPlates.item,Character.valueOf('D'), Block.blockDiamond});
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.helmet_suit_paintable.item, 1), new Object[] {"#D#", "# #", Character.valueOf('D'), Block.blockDiamond, Character.valueOf('#'), ItemIDs.reinforcedPlates.item });
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.boots_suit_paintable.item, 1), new Object[] {" D ","X X", "XFX", Character.valueOf('F'), Items.feather, Character.valueOf('D'), Items.diamond, Character.valueOf('X'), ItemIDs.reinforcedPlates.item});
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.pants_suit_paintable.item, 1), new Object[] { "XDX", "X$X", "X X", Character.valueOf('$'), Items.fire_charge, Character.valueOf('X'), ItemIDs.reinforcedPlates.item,Character.valueOf('D'), Items.diamond});
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.jacket_suit_paintable.item, 1), new Object[] { "X X", "XDX", "XAX", Character.valueOf('A'), Items.golden_apple, Character.valueOf('X'), ItemIDs.reinforcedPlates.item,Character.valueOf('D'), Blocks.diamond_block});
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.helmet_suit_paintable.item, 1), new Object[] {"#D#", "# #", Character.valueOf('D'), Blocks.diamond_block, Character.valueOf('#'), ItemIDs.reinforcedPlates.item });
 
 		/* Trains parts */
 
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.generator.item, 1), new Object[] { " ##", "E$$", " ##", Character.valueOf('#'), ItemIDs.copperWireFine.item, Character.valueOf('E'), ItemIDs.electronicCircuit.item, Character.valueOf('$'), Item.ingotIron });// generator
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.controls.item, 1), new Object[] { "#X#", "#E#", "$$$", Character.valueOf('#'), Block.lever, Character.valueOf('X'), Block.stoneButton, Character.valueOf('$'), Item.ingotIron, Character.valueOf('E'), ItemIDs.electronicCircuit.item });// train controls
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.generator.item, 1), new Object[] { " ##", "E$$", " ##", Character.valueOf('#'), ItemIDs.copperWireFine.item, Character.valueOf('E'), ItemIDs.electronicCircuit.item, Character.valueOf('$'), Items.iron_ingot });// generator
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.controls.item, 1), new Object[] { "#X#", "#E#", "$$$", Character.valueOf('#'), Blocks.lever, Character.valueOf('X'), Blocks.stone_button, Character.valueOf('$'), Items.iron_ingot, Character.valueOf('E'), ItemIDs.electronicCircuit.item });// train controls
 		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.dieselengine.item, 2), new Object[] { "###", "XXX", "CCC", Character.valueOf('#'), ItemIDs.piston.item, Character.valueOf('X'), ItemIDs.cylinder.item, Character.valueOf('C'), ItemIDs.camshaft.item });// diesel engine 
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.electmotor.item, 1), new Object[] { "I#I", "#E#", "I#I", Character.valueOf('#'), ItemIDs.copperWireFine.item, Character.valueOf('I'), Item.ingotIron, Character.valueOf('E'), ItemIDs.electronicCircuit.item });// Electric motor 
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.electmotor.item, 1), new Object[] { "I#I", "#E#", "I#I", Character.valueOf('#'), ItemIDs.copperWireFine.item, Character.valueOf('I'), Items.iron_ingot, Character.valueOf('E'), ItemIDs.electronicCircuit.item });// Electric motor 
 		ArrayList<ItemStack> dustCoal = OreDictionary.getOres("dustCoal");
 		if (dustCoal != null && dustCoal.size() >= 0) {
 			for (int t = 0; t < dustCoal.size(); t++) {
-				TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.graphite.item, 2), new Object[] { "###", "#X#", "###", Character.valueOf('#'), dustCoal.get(t), Character.valueOf('X'), Item.clay });// Graphite
+				TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.graphite.item, 2), new Object[] { "###", "#X#", "###", Character.valueOf('#'), dustCoal.get(t), Character.valueOf('X'), Items.clay_ball });// Graphite
 			}
 		}
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.ironBoiler.item, 2), new Object[] { "###", "XXX", "###", Character.valueOf('#'), Item.ingotIron, Character.valueOf('X'), Item.bucketWater });// iron Boiler 
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.ironFirebox.item, 2), new Object[] { "###", "#X#", "###", Character.valueOf('#'), Item.ingotIron, Character.valueOf('X'), Item.flintAndSteel });// iron Firebox  
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.ironChimney.item, 2), new Object[] { "# #", "# #", "# #", Character.valueOf('#'), Item.ingotIron });
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.ironBoiler.item, 2), new Object[] { "###", "XXX", "###", Character.valueOf('#'), Items.iron_ingot, Character.valueOf('X'), Items.water_bucket });// iron Boiler 
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.ironFirebox.item, 2), new Object[] { "###", "#X#", "###", Character.valueOf('#'), Items.iron_ingot, Character.valueOf('X'), Items.flint_and_steel });// iron Firebox  
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.ironChimney.item, 2), new Object[] { "# #", "# #", "# #", Character.valueOf('#'), Items.iron_ingot });
 		
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.coaldust.item, 4), new Object[] { "###","   ","   ", Character.valueOf('#'), Item.coal });
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.coaldust.item, 4), new Object[] { "   ","###","   ", Character.valueOf('#'), Item.coal });
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.coaldust.item, 4), new Object[] { "   ","   ","###", Character.valueOf('#'), Item.coal });
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.coaldust.item, 4), new Object[] { "###","   ","   ", Character.valueOf('#'), Items.coal });
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.coaldust.item, 4), new Object[] { "   ","###","   ", Character.valueOf('#'), Items.coal });
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.coaldust.item, 4), new Object[] { "   ","   ","###", Character.valueOf('#'), Items.coal });
 		
-		//TrainCraftingManager.instance.addShapelessRecipe(new ItemStack(ItemIDs.coaldust.item, 4), new Object[] { Item.coal, Item.coal, Item.coal, Item.coal });// coal dust
+		//TrainCraftingManager.instance.addShapelessRecipe(new ItemStack(ItemIDs.coaldust.item, 4), new Object[] { Items.coal, Items.coal, Items.coal, Items.coal });// coal dust
 		
-		//TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.signal.item, 2), new Object[] { "#", "X", "X", Character.valueOf('X'), ItemIDs.steel.item, Character.valueOf('#'), Item.redstone });
+		//TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.signal.item, 2), new Object[] { "#", "X", "X", Character.valueOf('X'), ItemIDs.steel.item, Character.valueOf('#'), Items.redstone });
 		/* diesel generator */
 		TrainCraftingManager.instance.addRecipe(new ItemStack(BlockIDs.generatorDiesel.block, 1), new Object[] { "C  ", "DE ", Character.valueOf('C'), ItemIDs.steelchimney.item, Character.valueOf('D'), ItemIDs.dieselengine.item, Character.valueOf('E'), ItemIDs.electronicCircuit.item });
 		
 		/* Zepplin parts and zeppelin item */
 		if (ConfigHandler.ENABLE_ZEPPELIN) {
-			TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.balloon.item, 1), new Object[] { "###", "# #", "###", Character.valueOf('#'), Block.cloth });// Balloon  
+			TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.balloon.item, 1), new Object[] { "###", "# #", "###", Character.valueOf('#'), Blocks.wool });// Balloon  
 			TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.steamengine.item, 1), new Object[] { "C  ", "BF ", Character.valueOf('C'), ItemIDs.steelchimney.item, Character.valueOf('B'), ItemIDs.boiler.item, Character.valueOf('F'), ItemIDs.firebox.item });// Small steam engine 
-			TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.airship.item, 1), new Object[] { "B B", "SES", "POP", Character.valueOf('B'), ItemIDs.balloon.item, Character.valueOf('S'), Item.stick, Character.valueOf('E'), ItemIDs.steamengine.item, Character.valueOf('P'), ItemIDs.propeller.item, Character.valueOf('O'), Item.boat });
+			TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.airship.item, 1), new Object[] { "B B", "SES", "POP", Character.valueOf('B'), ItemIDs.balloon.item, Character.valueOf('S'), Items.stick, Character.valueOf('E'), ItemIDs.steamengine.item, Character.valueOf('P'), ItemIDs.propeller.item, Character.valueOf('O'), Items.boat });
 			TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.zeppelin.item, 1), new Object[] { "BBB", "SES", "POP", Character.valueOf('B'), ItemIDs.balloon.item, Character.valueOf('S'), ItemIDs.propeller.item, Character.valueOf('E'), ItemIDs.controls.item, Character.valueOf('P'), ItemIDs.electmotor.item, Character.valueOf('O'), ItemIDs.seats.item });
 		}
 		
@@ -174,38 +176,38 @@ public class RecipeHandler {
 				if (steel != null && steel.size() >= 0) {
 					for (int t = 0; t < steel.size(); t++) {
 						
-						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.reinforcedPlates.item, 1), new Object[] { "RRR", "SSS", "CCC", Character.valueOf('R'), ItemIDs.reinforcedPlastic.item, Character.valueOf('S'), steel.get(t), Character.valueOf('C'), Item.clay});
+						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.reinforcedPlates.item, 1), new Object[] { "RRR", "SSS", "CCC", Character.valueOf('R'), ItemIDs.reinforcedPlastic.item, Character.valueOf('S'), steel.get(t), Character.valueOf('C'), Items.clay_ball});
 						
 						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.composite_wrench.item, 1), new Object[] {"S S", " R "," R ", Character.valueOf('R'), ItemIDs.reinforcedPlastic.item, Character.valueOf('S'),steel.get(t) });
 						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.steelcab.item, 2), new Object[] { "###", "X X", "XXX", Character.valueOf('X'), steel.get(t), Character.valueOf('#'), s1.get(i) });// Steel cab
 						TrainCraftingManager.instance.addRecipe(new ItemStack(BlockIDs.distilIdle.block, 1), new Object[] { "###", "#F#", "###", Character.valueOf('#'), steel.get(t), Character.valueOf('F'), ItemIDs.firebox.item });
-						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.transformer.item, 1), new Object[] { "# #", "XEX", "###", Character.valueOf('#'), steel.get(t), Character.valueOf('E'), ItemIDs.electronicCircuit.item, Character.valueOf('X'), Item.redstone });// transformer
+						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.transformer.item, 1), new Object[] { "# #", "XEX", "###", Character.valueOf('#'), steel.get(t), Character.valueOf('E'), ItemIDs.electronicCircuit.item, Character.valueOf('X'), Items.redstone });// transformer
 						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.minecartLocoMineTrain.item, 1), new Object[] { "X#X", "XXX", Character.valueOf('X'), steel.get(t), Character.valueOf('#'), ItemIDs.electmotor.item });
 						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.minecartLocoMineTrain.item, 1), new Object[] { "   ", "X#X", "XXX", Character.valueOf('X'), steel.get(t), Character.valueOf('#'), ItemIDs.electmotor.item });
-						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.minecartMineTrain.item, 1), new Object[] { "X#X", "XXX", Character.valueOf('X'), steel.get(t), Character.valueOf('#'), Block.chest });
-						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.minecartMineTrain.item, 1), new Object[] { "   ", "X#X", "XXX", Character.valueOf('X'), steel.get(t), Character.valueOf('#'), Block.chest });
+						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.minecartMineTrain.item, 1), new Object[] { "X#X", "XXX", Character.valueOf('X'), steel.get(t), Character.valueOf('#'), Blocks.chest });
+						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.minecartMineTrain.item, 1), new Object[] { "   ", "X#X", "XXX", Character.valueOf('X'), steel.get(t), Character.valueOf('#'), Blocks.chest });
 
-						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.boiler.item, 2), new Object[] { "###", "XXX", "###", Character.valueOf('#'), steel.get(t), Character.valueOf('X'), Item.bucketWater });// Boiler 
-						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.firebox.item, 2), new Object[] { "###", "#X#", "###", Character.valueOf('#'), steel.get(t), Character.valueOf('X'), Item.flintAndSteel });// Firebox 
-						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.bogie.item, 4), new Object[] { " # ", "#X#", " # ", Character.valueOf('#'), steel.get(t), Character.valueOf('X'), Item.ingotIron });// Bogie 
-						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.steelframe.item, 2), new Object[] { "# #", "AAA", Character.valueOf('A'), steel.get(t), Character.valueOf('#'), Item.ingotIron });// Steel Frame 
-						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.steelframe.item, 2), new Object[] { "   ", "# #", "AAA", Character.valueOf('A'), steel.get(t), Character.valueOf('#'), Item.ingotIron });// Steel Frame  
+						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.boiler.item, 2), new Object[] { "###", "XXX", "###", Character.valueOf('#'), steel.get(t), Character.valueOf('X'), Items.water_bucket });// Boiler 
+						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.firebox.item, 2), new Object[] { "###", "#X#", "###", Character.valueOf('#'), steel.get(t), Character.valueOf('X'), Items.flint_and_steel });// Firebox 
+						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.bogie.item, 4), new Object[] { " # ", "#X#", " # ", Character.valueOf('#'), steel.get(t), Character.valueOf('X'), Items.iron_ingot });// Bogie 
+						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.steelframe.item, 2), new Object[] { "# #", "AAA", Character.valueOf('A'), steel.get(t), Character.valueOf('#'), Items.iron_ingot });// Steel Frame 
+						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.steelframe.item, 2), new Object[] { "   ", "# #", "AAA", Character.valueOf('A'), steel.get(t), Character.valueOf('#'), Items.iron_ingot });// Steel Frame  
 						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.steelchimney.item, 2), new Object[] { "# #", "# #", "# #", Character.valueOf('#'), steel.get(t) });// Bogie 
-						TrainCraftingManager.instance.addRecipe(new ItemStack(Item.flintAndSteel, 2), new Object[] { "* ", " #", Character.valueOf('*'), steel.get(t), Character.valueOf('#'), Item.flint });
+						TrainCraftingManager.instance.addRecipe(new ItemStack(Items.flint_and_steel, 2), new Object[] { "* ", " #", Character.valueOf('*'), steel.get(t), Character.valueOf('#'), Items.flint });
 
-						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.stake.item, 1), new Object[] { "   ", "IFI", "   ", Character.valueOf('I'), steel.get(t), Character.valueOf('F'), Item.ingotIron });
-						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.stake.item, 1), new Object[] { "IFI", "   ", "   ", Character.valueOf('I'), steel.get(t), Character.valueOf('F'), Item.ingotIron });
-						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.stake.item, 1), new Object[] { "   ", "   ", "IFI", Character.valueOf('I'), steel.get(t), Character.valueOf('F'), Item.ingotIron });
+						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.stake.item, 1), new Object[] { "   ", "IFI", "   ", Character.valueOf('I'), steel.get(t), Character.valueOf('F'), Items.iron_ingot });
+						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.stake.item, 1), new Object[] { "IFI", "   ", "   ", Character.valueOf('I'), steel.get(t), Character.valueOf('F'), Items.iron_ingot });
+						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.stake.item, 1), new Object[] { "   ", "   ", "IFI", Character.valueOf('I'), steel.get(t), Character.valueOf('F'), Items.iron_ingot });
 
 						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.transmition.item, 1), new Object[] { " # ", "#X#", " # ", Character.valueOf('#'), steel.get(t), Character.valueOf('X'), ItemIDs.diesel.item });// transmition
-						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.piston.item, 3), new Object[] { " # ", " X ", Character.valueOf('#'), steel.get(t), Character.valueOf('X'), Item.stick });// piston
+						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.piston.item, 3), new Object[] { " # ", " X ", Character.valueOf('#'), steel.get(t), Character.valueOf('X'), Items.stick });// piston
 						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.camshaft.item, 3), new Object[] { "###", "   ", "   ", Character.valueOf('#'), steel.get(t) });// camshaft 
 						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.camshaft.item, 3), new Object[] { "   ", "###", "   ", Character.valueOf('#'), steel.get(t) });// camshaft
 						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.camshaft.item, 3), new Object[] { "   ", "   ", "###", Character.valueOf('#'), steel.get(t) });// camshaft
 						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.cylinder.item, 3), new Object[] { "# #", "# #", "###", Character.valueOf('#'), steel.get(t) });// cylinder 
-						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.propeller.item, 2), new Object[] { " # ", "#X#", " # ", Character.valueOf('#'), s1.get(i), Character.valueOf('X'), Item.ingotIron });// Propeller
+						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.propeller.item, 2), new Object[] { " # ", "#X#", " # ", Character.valueOf('#'), s1.get(i), Character.valueOf('X'), Items.iron_ingot });// Propeller
 						
-						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.tcRailSmallStraight.item, 32), new Object[] { "I I", "SPS", "I I", Character.valueOf('P'), s1.get(i), Character.valueOf('I'), Item.ingotIron, Character.valueOf('S'), steel.get(t) });// small straight track
+						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.tcRailSmallStraight.item, 32), new Object[] { "I I", "SPS", "I I", Character.valueOf('P'), s1.get(i), Character.valueOf('I'), Items.iron_ingot, Character.valueOf('S'), steel.get(t) });// small straight track
 					}
 				}
 				if (s2 != null && s2.size() >= 0) {
@@ -213,20 +215,20 @@ public class RecipeHandler {
 						/* Water Wheel */
 						TrainCraftingManager.instance.addRecipe(new ItemStack(BlockIDs.waterWheel.block, 1), new Object[] { " P ", "PGP", " P ", Character.valueOf('P'), s2.get(j),Character.valueOf('G'), ItemIDs.generator.item});
 						/* Wind mill */
-						TrainCraftingManager.instance.addRecipe(new ItemStack(BlockIDs.windMill.block, 1), new Object[] { " R ", " G ", "B B",Character.valueOf('G'), ItemIDs.generator.item, Character.valueOf('B'), Item.ingotIron, Character.valueOf('R'), ItemIDs.propeller.item});
+						TrainCraftingManager.instance.addRecipe(new ItemStack(BlockIDs.windMill.block, 1), new Object[] { " R ", " G ", "B B",Character.valueOf('G'), ItemIDs.generator.item, Character.valueOf('B'), Items.iron_ingot, Character.valueOf('R'), ItemIDs.propeller.item});
 						
 						TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.woodenBogie.item, 4), new Object[] { " # ", "#X#", " # ", Character.valueOf('#'), s1.get(i), Character.valueOf('X'), s2.get(j) });// wooden Bogie
 					}
 				}
-				TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.seats.item, 1), new Object[] { "#  ", "## ", "XXX", Character.valueOf('#'), s1.get(i), Character.valueOf('X'), Item.ingotIron });// transformer
+				TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.seats.item, 1), new Object[] { "#  ", "## ", "XXX", Character.valueOf('#'), s1.get(i), Character.valueOf('X'), Items.iron_ingot });// transformer
 				TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.woodenFrame.item, 2), new Object[] { "# #", "AAA", Character.valueOf('A'), s1.get(i), Character.valueOf('#'), s1.get(i) });// wooden Frame
 				TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.woodenFrame.item, 2), new Object[] { "   ", "# #", "AAA", Character.valueOf('A'), s1.get(i), Character.valueOf('#'), s1.get(i) });// wooden Frame
 				TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.woodenCab.item, 2), new Object[] { "###", "X X", "XXX", Character.valueOf('X'), s1.get(i), Character.valueOf('#'), s1.get(i) });// wooden cab
-				TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.ironBogie.item, 4), new Object[] { " # ", "#X#", " # ", Character.valueOf('#'), Item.ingotIron, Character.valueOf('X'), s1.get(i) });// iron Bogie
-				TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.ironFrame.item, 2), new Object[] { "# #", "AAA", Character.valueOf('A'), Item.ingotIron, Character.valueOf('#'), s1.get(i) });// iron Frame
-				TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.ironFrame.item, 2), new Object[] { "   ", "# #", "AAA", Character.valueOf('A'), Item.ingotIron, Character.valueOf('#'), s1.get(i) });// iron Frame
-				TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.ironCab.item, 2), new Object[] { "###", "X X", "XXX", Character.valueOf('X'), Item.ingotIron, Character.valueOf('#'), s1.get(i) });// iron cab
-				TrainCraftingManager.instance.addRecipe(new ItemStack(BlockIDs.stopper.block, 1), new Object[] { "WWW", "I I", "RRR", Character.valueOf('W'), s1.get(i), Character.valueOf('R'), Block.rail, Character.valueOf('I'), Item.ingotIron});// stopper
+				TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.ironBogie.item, 4), new Object[] { " # ", "#X#", " # ", Character.valueOf('#'), Items.iron_ingot, Character.valueOf('X'), s1.get(i) });// iron Bogie
+				TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.ironFrame.item, 2), new Object[] { "# #", "AAA", Character.valueOf('A'), Items.iron_ingot, Character.valueOf('#'), s1.get(i) });// iron Frame
+				TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.ironFrame.item, 2), new Object[] { "   ", "# #", "AAA", Character.valueOf('A'), Items.iron_ingot, Character.valueOf('#'), s1.get(i) });// iron Frame
+				TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.ironCab.item, 2), new Object[] { "###", "X X", "XXX", Character.valueOf('X'), Items.iron_ingot, Character.valueOf('#'), s1.get(i) });// iron cab
+				TrainCraftingManager.instance.addRecipe(new ItemStack(BlockIDs.stopper.block, 1), new Object[] { "WWW", "I I", "RRR", Character.valueOf('W'), s1.get(i), Character.valueOf('R'), Blocks.rail, Character.valueOf('I'), Items.iron_ingot});// stopper
 				
 				TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.tcRailLargeSlopeWood.item, 2), new Object[] {"  S", " SW","SWW", Character.valueOf('S'), ItemIDs.tcRailSmallStraight.item,Character.valueOf('W'), s1.get(i) });// straight slopes
 			}
@@ -256,13 +258,14 @@ public class RecipeHandler {
 		
 		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.tcRailTwoWaysCrossing.item, 4), new Object[] {" S ", "SSS"," S ", Character.valueOf('S'), ItemIDs.tcRailSmallStraight.item });// two ways crossing
 		
-		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.tcRailLargeSlopeGravel.item, 2), new Object[] {"  S", " SG","SGG", Character.valueOf('S'), ItemIDs.tcRailSmallStraight.item,Character.valueOf('G'), Block.gravel });// straight slopes
+		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.tcRailLargeSlopeGravel.item, 2), new Object[] {"  S", " SG","SGG", Character.valueOf('S'), ItemIDs.tcRailSmallStraight.item,Character.valueOf('G'), Blocks.gravel });// straight slopes
 		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.tcRailLargeSlopeBallast.item, 2), new Object[] {"  S", " SB","SBB", Character.valueOf('S'), ItemIDs.tcRailSmallStraight.item,Character.valueOf('B'), new ItemStack(BlockIDs.oreTC.block, 1,3) });// straight slopes
 		
-		TrainCraftingManager.instance.addRecipe(new ItemStack(BlockIDs.bridgePillar.block, 4), new Object[] {"SSS", "S S","SSS", Character.valueOf('S'), Item.stick});// bridge pillar
+		TrainCraftingManager.instance.addRecipe(new ItemStack(BlockIDs.bridgePillar.block, 4), new Object[] {"SSS", "S S","SSS", Character.valueOf('S'), Items.stick});// bridge pillar
 		
 		/* Smelting recipes */
-		FurnaceRecipes.smelting().addSmelting(BlockIDs.oreTC.block.blockID, 0, OreDictionary.getOres("ingotCopper").get(0), 0.7f);
+		// NOTE: func_151393_a = addSmelting
+		FurnaceRecipes.smelting().func_151393_a(BlockIDs.oreTC.block, OreDictionary.getOres("ingotCopper").get(0), 0.7f);
 	}
 
 	public static void addDictRecipe(ItemStack stack, Object... obj) {

--- a/src/main/java/src/train/common/core/managers/TierRecipe.java
+++ b/src/main/java/src/train/common/core/managers/TierRecipe.java
@@ -8,8 +8,11 @@
 package src.train.common.core.managers;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 import src.train.common.api.crafting.ITierRecipe;
@@ -17,48 +20,32 @@ import src.train.common.api.crafting.ITierRecipe;
 public class TierRecipe implements ITierRecipe {
 
 	private final int tier;
-	private final ItemStack planks;
-	private final ItemStack wheels;
-	private final ItemStack frame;
-	private final ItemStack coupler;
-	private final ItemStack chimney;
-	private final ItemStack cab;
-	private final ItemStack boiler;
-	private final ItemStack firebox;
-	private final ItemStack additional;
-	private final ItemStack dye;
 	private final ItemStack output;
 	private final int outputSize;
 
-	private final List<ItemStack> stacks;
+	private final ItemStack[] stacks;
 
-	public TierRecipe(int tier, ItemStack planks, ItemStack wheels, ItemStack frame, ItemStack coupler, ItemStack chimney, ItemStack cab, ItemStack boiler, ItemStack firebox, ItemStack additional, ItemStack dye, ItemStack output, int outputSize) {
+	public TierRecipe(int tier, ItemStack planks, ItemStack wheels,
+			ItemStack frame, ItemStack coupler, ItemStack chimney,
+			ItemStack cab, ItemStack boiler, ItemStack firebox,
+			ItemStack additional, ItemStack dye, ItemStack output,
+			int outputSize) {
 		this.tier = tier;
-		this.planks = planks;
-		this.wheels = wheels;
-		this.frame = frame;
-		this.coupler = coupler;
-		this.chimney = chimney;
-		this.cab = cab;
-		this.boiler = boiler;
-		this.firebox = firebox;
-		this.additional = additional;
-		this.dye = dye;
 		this.output = output;
 		this.outputSize = outputSize;
 
-		stacks = new ArrayList<ItemStack>();
-
-		stacks.add(0, planks);
-		stacks.add(1, wheels);
-		stacks.add(2, frame);
-		stacks.add(3, coupler);
-		stacks.add(4, chimney);
-		stacks.add(5, cab);
-		stacks.add(6, boiler);
-		stacks.add(7, firebox);
-		stacks.add(8, additional);
-		stacks.add(9, dye);
+		stacks = new ItemStack[] {
+			planks,
+			wheels,
+			frame,
+			coupler,
+			chimney,
+			cab,
+			boiler,
+			firebox,
+			additional,
+			dye,
+		};
 	}
 
 	@Override
@@ -83,111 +70,54 @@ public class TierRecipe implements ITierRecipe {
 
 	@Override
 	public ItemStack getRecipeIn(int slot) {
-		ItemStack stack;
-		switch (slot) {
-		case 0:
-			stack = planks;
-		case 1:
-			stack = wheels;
-		case 2:
-			stack = frame;
-		case 3:
-			stack = coupler;
-		case 4:
-			stack = chimney;
-		case 5:
-			stack = cab;
-		case 6:
-			stack = boiler;
-		case 7:
-			stack = firebox;
-		case 8:
-			stack = additional;
-		case 9:
-			stack = dye;
-		default:
-			stack = null;
-		}
-		return stack;
-	}
-
-	@Override
-	public List<ItemStack> getInput() {
-		List<ItemStack> list = getList(planks, wheels, frame, coupler, chimney, cab, boiler, firebox, additional, dye);
-		return list;
-	}
-
-	public static List getList(ItemStack planks, ItemStack wheels, ItemStack frame, ItemStack coupler, ItemStack chimney, ItemStack cab, ItemStack boiler, ItemStack firebox, ItemStack additional, ItemStack dye) {
-		List<ItemStack> list = new ArrayList<ItemStack>();
-		list.add(0, planks);
-		list.add(1, wheels);
-		list.add(2, frame);
-		list.add(3, coupler);
-		list.add(4, chimney);
-		list.add(5, cab);
-		list.add(6, boiler);
-		list.add(7, firebox);
-		list.add(8, additional);
-		list.add(9, dye);
-		return list;
-	}
-
-	public ItemStack hasComponents(ItemStack planks, ItemStack wheels, ItemStack frame, ItemStack coupler, ItemStack chimney, ItemStack cab, ItemStack boiler, ItemStack firebox, ItemStack additional, ItemStack dye) {
-		List<ItemStack> list = getList(planks, wheels, frame, coupler, chimney, cab, boiler, firebox, additional, dye);
-		int x = 0;
-		for (int i = 0; i < 10; i++) {
-			if (areItemsIdentical(list.get(i), stacks.get(i)) && areSizesIdentical(list.get(i), stacks.get(i))) {
-				x++;
-			}
-		}
-		if (x == 10) {
-			return output;
+		if(slot < stacks.length) {
+			return stacks[slot].copy();
 		}
 		return null;
 	}
 
+	@Override
+	public List<ItemStack> getInput() {
+		return Arrays.asList(stacks);
+	}
+
+	public ItemStack hasComponents(ItemStack... items) {
+		for (int i = 0; i < stacks.length; i++) {
+			if(!areItemsIdentical(items[i], stacks[i])) {
+				return null;
+			}
+			if(!areSizesIdentical(items[i], stacks[i])) {
+				return null;
+			}
+		}
+		return output;
+	}
+
 	public static boolean areItemsIdentical(ItemStack inSlot, ItemStack inRecipe) {
-		if (inRecipe == null) {
-			return true;
-		}
-		else {
+		if (inRecipe == null || inSlot == null) {
+			return inRecipe == inSlot;
+		} else {
+			if (Item.getIdFromItem(inSlot.getItem()) != Item.getIdFromItem(inRecipe.getItem())) {
+				return false;
+			}
 			if (inRecipe.getItemDamage() == OreDictionary.WILDCARD_VALUE) {
-				if (inSlot == null && inRecipe != null) {
-					return false;
-				}
-				if ((inSlot.itemID == inRecipe.itemID)) {
-					return true;
-				}
+				return true;
 			}
-			else {
-				if (inSlot == null && inRecipe != null) {
-					return false;
-				}
-				if ((inSlot.itemID == inRecipe.itemID) && (inSlot.getItemDamage() == inRecipe.getItemDamage())) {
-					return true;
-				}
-			}
+			return inSlot.getItemDamage() == inRecipe.getItemDamage();
 		}
-		return false;
 	}
 
 	public static boolean areSizesIdentical(ItemStack inSlot, ItemStack inRecipe) {
-		if (inRecipe == null) {
-			return true;
+		if (inRecipe == null || inSlot == null) {
+			return inRecipe == inSlot;
 		}
-		if (inSlot == null && inRecipe != null) {
-			return false;
-		}
-		if (inSlot.stackSize >= inRecipe.stackSize) {
-			return true;
-		}
-		return false;
+		return inSlot.stackSize >= inRecipe.stackSize;
 	}
 
 	@Override
 	public int toDecrease(int slot) {
-		if (stacks.get(slot) != null) {
-			return stacks.get(slot).stackSize;
+		if (slot < stacks.length) {
+			return stacks[slot].stackSize;
 		}
 		return 0;
 	}

--- a/src/main/java/src/train/common/core/managers/TierRecipeManager.java
+++ b/src/main/java/src/train/common/core/managers/TierRecipeManager.java
@@ -10,17 +10,18 @@ package src.train.common.core.managers;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import src.train.common.api.crafting.ITierCraftingManager;
 import src.train.common.api.crafting.ITierRecipe;
 
 public class TierRecipeManager implements ITierCraftingManager {
 
-	private final List<TierRecipe> recipeList;
+	private final List<ITierRecipe> recipeList;
 	private static TierRecipeManager instance = new TierRecipeManager();
 
 	public TierRecipeManager() {
-		recipeList = new ArrayList<TierRecipe>();
+		recipeList = new ArrayList<ITierRecipe>();
 	}
 
 	public static ITierCraftingManager getInstance() {
@@ -28,98 +29,117 @@ public class TierRecipeManager implements ITierCraftingManager {
 	}
 
 	@Override
-	public void addRecipe(ItemStack planks, ItemStack wheels, ItemStack frame, ItemStack coupler, ItemStack chimney, ItemStack cab, ItemStack boiler, ItemStack firebox, ItemStack additional, ItemStack dye, ItemStack output) {
-		addRecipeFinal(1, planks, wheels, frame, coupler, chimney, cab, boiler, firebox, additional, dye, output, 1);
+	public void addRecipe(ItemStack planks, ItemStack wheels, ItemStack frame,
+			ItemStack coupler, ItemStack chimney, ItemStack cab,
+			ItemStack boiler, ItemStack firebox, ItemStack additional,
+			ItemStack dye, ItemStack output) {
+		addRecipeFinal(1, planks, wheels, frame, coupler, chimney, cab, boiler,
+				firebox, additional, dye, output, 1);
 	}
 
 	@Override
-	public void addRecipe(int tier, ItemStack planks, ItemStack wheels, ItemStack frame, ItemStack coupler, ItemStack chimney, ItemStack cab, ItemStack boiler, ItemStack firebox, ItemStack additional, ItemStack dye, ItemStack output) {
+	public void addRecipe(int tier, ItemStack planks, ItemStack wheels,
+			ItemStack frame, ItemStack coupler, ItemStack chimney,
+			ItemStack cab, ItemStack boiler, ItemStack firebox,
+			ItemStack additional, ItemStack dye, ItemStack output) {
 		if (tier > 0 && tier < 4) {
-			addRecipeFinal(tier, planks, wheels, frame, coupler, chimney, cab, boiler, firebox, additional, dye, output, 1);
-		}
-		else {
-			addRecipeFinal(1, planks, wheels, frame, coupler, chimney, cab, boiler, firebox, additional, dye, output, 1);
+			addRecipeFinal(tier, planks, wheels, frame, coupler, chimney, cab,
+					boiler, firebox, additional, dye, output, 1);
+		} else {
+			addRecipeFinal(1, planks, wheels, frame, coupler, chimney, cab,
+					boiler, firebox, additional, dye, output, 1);
 		}
 	}
 
 	@Override
-	public void addRecipe(ItemStack planks, ItemStack wheels, ItemStack frame, ItemStack coupler, ItemStack chimney, ItemStack cab, ItemStack boiler, ItemStack firebox, ItemStack additional, ItemStack dye, ItemStack output, int outputSize) {
+	public void addRecipe(ItemStack planks, ItemStack wheels, ItemStack frame,
+			ItemStack coupler, ItemStack chimney, ItemStack cab,
+			ItemStack boiler, ItemStack firebox, ItemStack additional,
+			ItemStack dye, ItemStack output, int outputSize) {
 		if (outputSize > 0 && outputSize < 65) {
-			addRecipeFinal(1, planks, wheels, frame, coupler, chimney, cab, boiler, firebox, additional, dye, output, outputSize);
-		}
-		else {
-			addRecipeFinal(1, planks, wheels, frame, coupler, chimney, cab, boiler, firebox, additional, dye, output, 1);
+			addRecipeFinal(1, planks, wheels, frame, coupler, chimney, cab,
+					boiler, firebox, additional, dye, output, outputSize);
+		} else {
+			addRecipeFinal(1, planks, wheels, frame, coupler, chimney, cab,
+					boiler, firebox, additional, dye, output, 1);
 		}
 	}
 
 	@Override
-	public void addRecipe(int tier, ItemStack planks, ItemStack wheels, ItemStack frame, ItemStack coupler, ItemStack chimney, ItemStack cab, ItemStack boiler, ItemStack firebox, ItemStack additional, ItemStack dye, ItemStack output, int outputSize) {
+	public void addRecipe(int tier, ItemStack planks, ItemStack wheels,
+			ItemStack frame, ItemStack coupler, ItemStack chimney,
+			ItemStack cab, ItemStack boiler, ItemStack firebox,
+			ItemStack additional, ItemStack dye, ItemStack output,
+			int outputSize) {
 		if ((tier > 0 && tier < 4) && outputSize > 0 && outputSize < 65) {
-			addRecipeFinal(tier, planks, wheels, frame, coupler, chimney, cab, boiler, firebox, additional, dye, output, outputSize);
-		}
-		else {
-			addRecipeFinal(1, planks, wheels, frame, coupler, chimney, cab, boiler, firebox, additional, dye, output, 1);
+			addRecipeFinal(tier, planks, wheels, frame, coupler, chimney, cab,
+					boiler, firebox, additional, dye, output, outputSize);
+		} else {
+			addRecipeFinal(1, planks, wheels, frame, coupler, chimney, cab,
+					boiler, firebox, additional, dye, output, 1);
 		}
 	}
 
-	public void addRecipeFinal(int tier, ItemStack planks, ItemStack wheels, ItemStack frame, ItemStack coupler, ItemStack chimney, ItemStack cab, ItemStack boiler, ItemStack firebox, ItemStack additional, ItemStack dye, ItemStack output, int outputSize) {
-		//if(!recipeAlreadyExists(tier, planks, wheels, frame, coupler, chimney, cab, boiler, firebox, additional, dye, output)) {
-		recipeList.add(new TierRecipe(tier, planks, wheels, frame, coupler, chimney, cab, boiler, firebox, additional, dye, output, outputSize));
+	public void addRecipeFinal(int tier, ItemStack planks, ItemStack wheels,
+			ItemStack frame, ItemStack coupler, ItemStack chimney,
+			ItemStack cab, ItemStack boiler, ItemStack firebox,
+			ItemStack additional, ItemStack dye, ItemStack output,
+			int outputSize) {
+		// if(!recipeAlreadyExists(tier, planks, wheels, frame, coupler,
+		// chimney, cab, boiler, firebox, additional, dye, output)) {
+		recipeList.add(new TierRecipe(tier, planks, wheels, frame, coupler,
+				chimney, cab, boiler, firebox, additional, dye, output,
+				outputSize));
 		/*
-		 * } else { Traincraft.tcLog.log(Level.SEVERE, "Recipe already exists, skipping: " + output.getDisplayName() + " : " + output.getItemName()); } */
+		 * } else { Traincraft.tcLog.log(Level.SEVERE,
+		 * "Recipe already exists, skipping: " + output.getDisplayName() + " : "
+		 * + output.getItemName()); }
+		 */
 	}
 
-	private boolean recipeAlreadyExists(int tier, ItemStack planks, ItemStack wheels, ItemStack frame, ItemStack coupler, ItemStack chimney, ItemStack cab, ItemStack boiler, ItemStack firebox, ItemStack additional, ItemStack dye, ItemStack output) {
-		boolean exists = false;
-		List list = new ArrayList(this.recipeList);
-		List checks = new ArrayList();
-		List<ItemStack> items = new ArrayList<ItemStack>();
-		items.add(0, planks);
-		items.add(1, wheels);
-		items.add(2, frame);
-		items.add(3, coupler);
-		items.add(4, chimney);
-		items.add(5, cab);
-		items.add(6, boiler);
-		items.add(7, firebox);
-		items.add(8, additional);
-		items.add(9, dye);
-		for (int i = 0; i < list.size(); i++) {
-			TierRecipe recipe = (TierRecipe) list.get(i);
-			for (int j = 0; j < 10; j++) {
-				if (recipe.getRecipeIn(j) == null && items.get(j) == null) {
-					checks.add(0);
-				}
-				else if (recipe.getRecipeIn(j) == null && items.get(j) != null || recipe.getRecipeIn(j) != null && items.get(j) == null) {
-					checks.add(1);
-				}
-				else if (recipe.getRecipeIn(j).itemID == items.get(j).itemID) {
-					checks.add(0);
-				}
-				else {
-					checks.add(1);
-				}
+	private boolean recipeAlreadyExists(int tier, ItemStack planks,
+			ItemStack wheels, ItemStack frame, ItemStack coupler,
+			ItemStack chimney, ItemStack cab, ItemStack boiler,
+			ItemStack firebox, ItemStack additional, ItemStack dye,
+			ItemStack output) {
+		ItemStack[] items =
+			new ItemStack[] {
+				planks,
+				wheels,
+				frame,
+				coupler,
+				chimney,
+				cab,
+				boiler,
+				firebox,
+				additional,
+				dye,
+			};
+		for (ITierRecipe recipe: this.recipeList) {
+			if(recipe.getTier() != tier) {
+				continue;
 			}
-			if (checks.contains(0) && recipe.getTier() == tier && recipe.getOutput().itemID == output.itemID) {
-				exists = true;
-				break;
+			if(Item.getIdFromItem(recipe.getOutput().getItem()) != Item.getIdFromItem(output.getItem())) {
+				continue;
 			}
-			else {
-				checks = new ArrayList();
+			for (int i = 0; i < 10; i++) {
+				if(TierRecipe.areItemsIdentical(items[i], recipe.getRecipeIn(i)) &&
+					TierRecipe.areSizesIdentical(items[i], recipe.getRecipeIn(i))) {
+					return true;
+				}
 			}
 		}
-		return exists;
+		return false;
 	}
 
 	@Override
 	public ITierRecipe getRecipe(ItemStack output) {
-		List list = new ArrayList(this.recipeList);
-		if (output != null) {
-			for (int i = 0; i < list.size(); i++) {
-				TierRecipe recipe = (TierRecipe) list.get(i);
-				if (recipe != null && recipe.getOutput().itemID == output.itemID) {
-					return recipe;
-				}
+		if(output == null) {
+			return null;
+		}
+		for(ITierRecipe recipe: recipeList) {
+			if(Item.getIdFromItem(recipe.getOutput().getItem()) == Item.getIdFromItem(output.getItem())) {
+				return recipe;
 			}
 		}
 		return null;
@@ -127,30 +147,29 @@ public class TierRecipeManager implements ITierCraftingManager {
 
 	@Override
 	public ITierRecipe getTierRecipe(int tier, ItemStack output) {
-		List list = new ArrayList(this.recipeList);
-		if (output != null) {
-			for (int i = 0; i < list.size(); i++) {
-				TierRecipe recipe = (TierRecipe) list.get(i);
-				if ((recipe != null && recipe.getOutput().itemID == output.itemID) && (recipe.getTier() == tier)) {
-					return recipe;
-				}
+		if(output == null) {
+			return null;
+		}
+		for(ITierRecipe recipe: recipeList) {
+			if(Item.getIdFromItem(recipe.getOutput().getItem()) == Item.getIdFromItem(output.getItem()) &&
+				recipe.getTier() == tier) {
+				return recipe;
 			}
 		}
 		return null;
 	}
 
 	@Override
-	public List<TierRecipe> getRecipeList() {
-		List<TierRecipe> list = new ArrayList<TierRecipe>(this.recipeList);
-		return list;
+	public List<ITierRecipe> getRecipeList() {
+		return new ArrayList<ITierRecipe>(this.recipeList);
 	}
 
 	@Override
-	public List<TierRecipe> getTierRecipeList(int tier) {
-		List<TierRecipe> list = new ArrayList<TierRecipe>();
-		for (int i = 0; i < recipeList.size(); i++) {
-			if (((TierRecipe) recipeList.get(i)).getTier() == tier) {
-				list.add(recipeList.get(i));
+	public List<ITierRecipe> getTierRecipeList(int tier) {
+		List<ITierRecipe> list = new ArrayList<ITierRecipe>();
+		for (ITierRecipe recipe: recipeList) {
+			if (recipe.getTier() == tier) {
+				list.add(recipe);
 			}
 		}
 		return list;
@@ -163,6 +182,12 @@ public class TierRecipeManager implements ITierCraftingManager {
 
 	@Override
 	public int getRecipeTierSize(int tier) {
-		return getTierRecipeList(tier).size();
+		int size = 0;
+		for (ITierRecipe recipe: recipeList) {
+			if (recipe.getTier() == tier) {
+				size += 1;
+			}
+		}
+		return size;
 	}
 }

--- a/src/main/java/src/train/common/tile/TileCrafterTierI.java
+++ b/src/main/java/src/train/common/tile/TileCrafterTierI.java
@@ -169,7 +169,7 @@ public class TileCrafterTierI extends TileEntity implements IInventory, ITier {
 		List<TierRecipe> recipes = TierRecipeManager.getInstance().getTierRecipeList(1);
 		int count = 0;
 		for (int j = 0; j < recipes.size(); j++) {
-			ItemStack stack = recipes.get(j).hasComponents(crafterInventory[0], crafterInventory[1], crafterInventory[2], crafterInventory[3], crafterInventory[4], crafterInventory[5], crafterInventory[6], crafterInventory[7], crafterInventory[8], crafterInventory[9]);
+			ItemStack stack = recipes.get(j).hasComponents(crafterInventory);
 			if (stack != null) {
 				resultList.add(stack);
 				crafterInventory[count + 10] = new ItemStack(stack.getItem(), 1, 0);

--- a/src/main/java/src/train/common/tile/TileCrafterTierII.java
+++ b/src/main/java/src/train/common/tile/TileCrafterTierII.java
@@ -169,7 +169,7 @@ public class TileCrafterTierII extends TileEntity implements IInventory, ITier {
 		List<TierRecipe> recipes = TierRecipeManager.getInstance().getTierRecipeList(2);
 		int count = 0;
 		for (int j = 0; j < recipes.size(); j++) {
-			ItemStack stack = recipes.get(j).hasComponents(crafterInventory[0], crafterInventory[1], crafterInventory[2], crafterInventory[3], crafterInventory[4], crafterInventory[5], crafterInventory[6], crafterInventory[7], crafterInventory[8], crafterInventory[9]);
+			ItemStack stack = recipes.get(j).hasComponents(crafterInventory);
 			if (stack != null) {
 				if((count+10)<crafterInventory.length) {
 					resultList.add(stack);

--- a/src/main/java/src/train/common/tile/TileCrafterTierIII.java
+++ b/src/main/java/src/train/common/tile/TileCrafterTierIII.java
@@ -164,7 +164,7 @@ public class TileCrafterTierIII extends TileEntity implements IInventory, ITier 
 		List<TierRecipe> recipes = TierRecipeManager.getInstance().getTierRecipeList(3);
 		int count = 0;
 		for (int j = 0; j < recipes.size(); j++) {
-			ItemStack stack = recipes.get(j).hasComponents(crafterInventory[0], crafterInventory[1], crafterInventory[2], crafterInventory[3], crafterInventory[4], crafterInventory[5], crafterInventory[6], crafterInventory[7], crafterInventory[8], crafterInventory[9]);
+			ItemStack stack = recipes.get(j).hasComponents(crafterInventory);
 			if (stack != null) {
 				resultList.add(stack);
 				crafterInventory[count + 10] = new ItemStack(stack.getItem(), 1, 0);


### PR DESCRIPTION
- AchievementHandler
  - Item -> Items
  - Block -> Blocks
  - setIndependent -> initIndependentStat
  - registerAchievement -> registerStat
  - Constructor of Achievement has changed
- FuelHandler
  - Updated away from IDs
  - There is still some aweful hardcoding going on
- ItemHandler
  - Refactored handleFreight and it's giant if-else chain
    - This uncovered quite few odd logic errors it has
    - There are odd instaceof Block checks when the variable can only
      have blocks
    - There is odd condition that after moving nullness check to before
      if chain is now dead code. So only way to get there was if it wasn't
      Block but Item. But even then it doesn't make sense because only thing
      the condition does is return false, which it would have done anyways,
      because all ifs check instanceof different entities.
- RecipeHandler
  - Item -> Items
  - Block -> Blocks
- TierRecipe
  - Removed unnessary fields
  - Simplified integrient storage
  - Simplified component checking
- TierRecipeManager
  - Simplified recipe exitence checking
  - Simplified recipe getting
