### PR TITLE
Fix EntityRollingStock move on restart.

### DIFF
--- a/src/main/java/train/common/api/EntityRollingStock.java
+++ b/src/main/java/train/common/api/EntityRollingStock.java
@@ -660,6 +660,21 @@ public class EntityRollingStock extends AbstractTrains implements ILinkableCart 
 			}
 		}
 		//super.onUpdate();
+		
+		/**
+		 * Set the uniqueID if the entity doesn't have one.
+		 */
+		if (!worldObj.isRemote && this.uniqueID == -1) {
+			if (FMLCommonHandler.instance().getMinecraftServerInstance() != null) {
+				TraincraftSaveHandler.createFile(FMLCommonHandler.instance().getMinecraftServerInstance());
+				int readID = TraincraftSaveHandler.readInt(FMLCommonHandler.instance().getMinecraftServerInstance(), "numberOfTrains:");
+				int newID = setNewUniqueID(readID);
+				TraincraftSaveHandler.writeValue(FMLCommonHandler.instance().getMinecraftServerInstance(), "numberOfTrains:", "" + newID);
+				statsEventHandler.trainPlace(newID, this.trainName, this.trainType, this.trainOwner, this.trainOwner, (int) posX + ";" + (int) posY + ";" + (int) posZ);
+				//System.out.println("Train is missing an ID, adding new one for "+this.trainName+" "+this.uniqueID);
+			}
+		}
+		
 		if (getRollingAmplitude() > 0) {
 			setRollingAmplitude(getRollingAmplitude() - 1);
 		}


### PR DESCRIPTION
Set the uniqueID to each entityRollingStock. This id is use to link them each time the world is loaded.
