### PR TITLE
Fix buildcraft pipe issue with TileEntityCrafterTier.

### DIFF
--- a/src/main/java/train/common/tile/TileCrafterTierI.java
+++ b/src/main/java/train/common/tile/TileCrafterTierI.java
@@ -296,8 +296,21 @@ public class TileCrafterTierI extends TileEntity implements IInventory, ITier {
 	}
 
 	@Override
-	public boolean isItemValidForSlot(int i, ItemStack itemstack) {
-		return true;
+	public boolean isItemValidForSlot(int i, ItemStack stack) {
+		if(i>17)
+			return true;
+		if(i>9)
+			return false;
+		
+		List<TierRecipe> recipeList = TierRecipeManager.getInstance().getTierRecipeList(this.Tier);
+		for(TierRecipe recipe : recipeList){
+			ItemStack stack2 = recipe.getInput().get(i);
+			if (stack2 != null && TierRecipe.areItemsIdentical(stack, stack2)) {
+				return true;
+			}
+		}
+		
+		return false;
 	}
 	
 	/*

--- a/src/main/java/train/common/tile/TileCrafterTierII.java
+++ b/src/main/java/train/common/tile/TileCrafterTierII.java
@@ -265,8 +265,21 @@ public class TileCrafterTierII extends TileEntity implements IInventory, ITier {
 	}
 
 	@Override
-	public boolean isItemValidForSlot(int i, ItemStack itemstack) {
-		return true;
+	public boolean isItemValidForSlot(int i, ItemStack stack) {
+		if(i>17)
+			return true;
+		if(i>9)
+			return false;
+		
+		List<TierRecipe> recipeList = TierRecipeManager.getInstance().getTierRecipeList(this.Tier);
+		for(TierRecipe recipe : recipeList){
+			ItemStack stack2 = recipe.getInput().get(i);
+			if (stack2 != null && TierRecipe.areItemsIdentical(stack, stack2)) {
+				return true;
+			}
+		}
+		
+		return false;
 	}
 	
 	@Override

--- a/src/main/java/train/common/tile/TileCrafterTierIII.java
+++ b/src/main/java/train/common/tile/TileCrafterTierIII.java
@@ -262,8 +262,21 @@ public class TileCrafterTierIII extends TileEntity implements IInventory, ITier 
 	public boolean hasCustomInventoryName() {return false;}
 
 	@Override
-	public boolean isItemValidForSlot(int i, ItemStack itemstack) {
-		return true;
+	public boolean isItemValidForSlot(int i, ItemStack stack) {
+		if(i>17)
+			return true;
+		if(i>9)
+			return false;
+		
+		List<TierRecipe> recipeList = TierRecipeManager.getInstance().getTierRecipeList(this.Tier);
+		for(TierRecipe recipe : recipeList){
+			ItemStack stack2 = recipe.getInput().get(i);
+			if (stack2 != null && TierRecipe.areItemsIdentical(stack, stack2)) {
+				return true;
+			}
+		}
+		
+		return false;
 	}
 	
 	@Override


### PR DESCRIPTION
- Now pipe send the item in the good slot when connected to an assembly table.
