### PR TITLE
Fix slope bug when walking on and TrackBuilder Crash

### DIFF
--- a/src/main/java/train/common/entity/rollingStock/EntityTracksBuilder.java
+++ b/src/main/java/train/common/entity/rollingStock/EntityTracksBuilder.java
@@ -186,7 +186,7 @@ public class EntityTracksBuilder extends EntityRollingStock implements IInventor
 					fuelTrain += 300;
 					decrStackInInvent(0, 1, 1);
 				}
-				if (BuilderInvent[0] != null && BuilderInvent[0].isItemEqual(PluginRailcraft.RailcraftParts.INGOT_STEEL.stack) && getFuel() + 800 < maxFuel) {
+				if (BuilderInvent[0] != null && PluginRailcraft.RailcraftParts.INGOT_STEEL.stack != null && BuilderInvent[0].isItemEqual(PluginRailcraft.RailcraftParts.INGOT_STEEL.stack) && getFuel() + 800 < maxFuel) {
 					fuelTrain += 800;
 					decrStackInInvent(0, 1, 1);
 				}

--- a/src/main/java/train/common/tile/TileTCRailGag.java
+++ b/src/main/java/train/common/tile/TileTCRailGag.java
@@ -3,6 +3,7 @@ package train.common.tile;
 import java.util.Random;
 
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.NetworkManager;
 import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
@@ -49,5 +50,11 @@ public class TileTCRailGag extends TileEntity {
 		this.writeToNBT(nbt);
 
 		return new S35PacketUpdateTileEntity(this.xCoord, this.yCoord, this.zCoord, 1, nbt);
+	}
+	
+	@Override
+	public void onDataPacket(NetworkManager net, S35PacketUpdateTileEntity pkt){
+		this.readFromNBT(pkt.func_148857_g());
+		super.onDataPacket(net, pkt);
 	}
 }


### PR DESCRIPTION
- Fix player stuck in slope bug by allowing tile entity synchronization
  for TileTCRailGag.
- Fix TrackBuilder Crach by checking if railcraft INGOT_STEEL != null
  before using it.
