### PR TITLE
Partial Fix For Train reverse on sharp. (and maybe multiple hitbox issue).

### DIFF
--- a/src/main/java/train/common/api/AbstractTrains.java
+++ b/src/main/java/train/common/api/AbstractTrains.java
@@ -220,10 +220,12 @@ public abstract class AbstractTrains extends EntityMinecart implements IMinecart
 		//if(this instanceof Locomotive)System.out.println("I'm alive. Remote: " + worldObj.isRemote);
 		if (!worldObj.isRemote && this.uniqueID == -1) {
 			if (FMLCommonHandler.instance().getMinecraftServerInstance() != null) {
-				TraincraftSaveHandler.createFile(FMLCommonHandler.instance().getMinecraftServerInstance());
-				int readID = TraincraftSaveHandler.readInt(FMLCommonHandler.instance().getMinecraftServerInstance(), "numberOfTrains:");
+				//TraincraftSaveHandler.createFile(FMLCommonHandler.instance().getMinecraftServerInstance());
+				//int readID = TraincraftSaveHandler.readInt(FMLCommonHandler.instance().getMinecraftServerInstance(), "numberOfTrains:");
+				//TraincraftSaveHandler seems to not work, may cause uniqueID bug.
+				int readID = -1;
 				int newID = setNewUniqueID(readID);
-				TraincraftSaveHandler.writeValue(FMLCommonHandler.instance().getMinecraftServerInstance(), "numberOfTrains:", "" + newID);
+				//TraincraftSaveHandler.writeValue(FMLCommonHandler.instance().getMinecraftServerInstance(), "numberOfTrains:", "" + newID);
 				statsEventHandler.trainPlace(newID, this.trainName, this.trainType, this.trainOwner, this.trainOwner, (int) posX + ";" + (int) posY + ";" + (int) posZ);
 				//System.out.println("Train is missing an ID, adding new one for "+this.trainName+" "+this.uniqueID);
 			}
@@ -320,6 +322,7 @@ public abstract class AbstractTrains extends EntityMinecart implements IMinecart
 		oldChunkCoordZ = this.chunkCoordZ;
 	}
 	public int setNewUniqueID(int numberOfTrains) {
+		System.out.println(numberOfTrains);
 		if (numberOfTrains <= 0) {
 			numberOfTrains = uniqueIDs++;
 		}
@@ -328,7 +331,7 @@ public abstract class AbstractTrains extends EntityMinecart implements IMinecart
 		}
 		this.uniqueID = numberOfTrains;
 		getEntityData().setInteger("uniqueID", numberOfTrains);
-		//System.out.println("setting new ID "+uniqueID);
+		System.out.println("setting new ID "+uniqueID);
 		return numberOfTrains;
 	}
 

--- a/src/main/java/train/common/api/EntityBogie.java
+++ b/src/main/java/train/common/api/EntityBogie.java
@@ -475,7 +475,6 @@ public class EntityBogie extends EntityMinecart implements IMinecart, IRoutableC
 
 						int meta = tileRail.getBlockMetadata();
 
-						System.out.println("pass " + i + " " + k);
 						shouldIgnoreSwitch(tileRail, i, j, k, meta);
 						moveOnTC90TurnRail(i, j, k, tileRail.r, tileRail.cx, tileRail.cy, tileRail.cz, tileRail.getType(), meta);
 					}

--- a/src/main/java/train/common/api/EntityRollingStock.java
+++ b/src/main/java/train/common/api/EntityRollingStock.java
@@ -435,10 +435,8 @@ public class EntityRollingStock extends AbstractTrains implements ILinkableCart 
 		setRollingAmplitude(10);
 		setDamage(getDamage() + getDamage() * 10);
 	}
-
-	@Override
-	public void setDead() {
-		super.setDead();
+	
+	public void unLink(){
 		if (this.isAttached) {
 			if (this.cartLinked1 != null) {
 				if (cartLinked1.Link1 == this.uniqueID) {
@@ -469,6 +467,12 @@ public class EntityRollingStock extends AbstractTrains implements ILinkableCart 
 				}
 			}
 		}
+	}
+
+	@Override
+	public void setDead() {
+		super.setDead();
+		this.unLink();
 		if (train != null) {
 			if (train.getTrains() != null) {
 				for (int i2 = 0; i2 < train.getTrains().size(); i2++) {
@@ -1110,6 +1114,7 @@ public class EntityRollingStock extends AbstractTrains implements ILinkableCart 
 						break;
 					if(!bogieLoco[loco].isOnRail()){
 						derailSpeed = 0;
+						this.unLink();
 						break;
 					}
 				}
@@ -1221,6 +1226,7 @@ public class EntityRollingStock extends AbstractTrains implements ILinkableCart 
 					}
 				}
 				if(derailSpeed == 0){
+					this.unLink();
 					int meta = tile.getBlockMetadata();
 					double cx = tile.xCoord;
 					double cy = tile.yCoord;

--- a/src/main/java/train/common/api/EntityRollingStock.java
+++ b/src/main/java/train/common/api/EntityRollingStock.java
@@ -466,6 +466,9 @@ public class EntityRollingStock extends AbstractTrains implements ILinkableCart 
 					//System.out.println("clear cartLinked2 link2");
 				}
 			}
+			this.cartLinked1 = null;
+			this.cartLinked2 = null;
+			this.isAttached = false;
 		}
 	}
 

--- a/src/main/java/train/common/api/EntityRollingStock.java
+++ b/src/main/java/train/common/api/EntityRollingStock.java
@@ -673,10 +673,15 @@ public class EntityRollingStock extends AbstractTrains implements ILinkableCart 
 		 */
 		if (!worldObj.isRemote && this.uniqueID == -1) {
 			if (FMLCommonHandler.instance().getMinecraftServerInstance() != null) {
-				TraincraftSaveHandler.createFile(FMLCommonHandler.instance().getMinecraftServerInstance());
-				int readID = TraincraftSaveHandler.readInt(FMLCommonHandler.instance().getMinecraftServerInstance(), "numberOfTrains:");
+				//TraincraftSaveHandler.createFile(FMLCommonHandler.instance().getMinecraftServerInstance());
+				//int readID = TraincraftSaveHandler.readInt(FMLCommonHandler.instance().getMinecraftServerInstance(), "numberOfTrains:");
+				//int newID = setNewUniqueID(readID);
+				
+					//TraincraftSaveHandler seems to not work, may cause uniqueID bug.
+				int readID = -1;
 				int newID = setNewUniqueID(readID);
-				TraincraftSaveHandler.writeValue(FMLCommonHandler.instance().getMinecraftServerInstance(), "numberOfTrains:", "" + newID);
+				
+				//TraincraftSaveHandler.writeValue(FMLCommonHandler.instance().getMinecraftServerInstance(), "numberOfTrains:", "" + newID);
 				statsEventHandler.trainPlace(newID, this.trainName, this.trainType, this.trainOwner, this.trainOwner, (int) posX + ";" + (int) posY + ";" + (int) posZ);
 				//System.out.println("Train is missing an ID, adding new one for "+this.trainName+" "+this.uniqueID);
 			}
@@ -797,6 +802,7 @@ public class EntityRollingStock extends AbstractTrains implements ILinkableCart 
 		if (addedToChunk && ((this.cartLinked1 == null && this.Link1 != 0) || (this.cartLinked2 == null && this.Link2 != 0))) {
 			AxisAlignedBB box2 = boundingBox.expand(15, 15, 15);
 			List lis = worldObj.getEntitiesWithinAABBExcludingEntity(this, box2);
+			//System.out.println("link " + this.uniqueID + " " + this + " to " + this.Link1 + " " + this.Link2);
 			if (lis != null && lis.size() > 0) {
 				for (int j1 = 0; j1 < lis.size(); j1++) {
 					Entity entity = (Entity) lis.get(j1);

--- a/src/main/java/train/common/blocks/BlockTCRail.java
+++ b/src/main/java/train/common/blocks/BlockTCRail.java
@@ -130,6 +130,9 @@ public class BlockTCRail extends Block {
 	public boolean onBlockActivated(World world, int i, int j, int k, EntityPlayer player, int par6, float par7, float par8, float par9) {
 		TileEntity te = world.getTileEntity(i, j, k);
 		int l = world.getBlockMetadata(i, j, k);
+		if((te instanceof TileTCRail)){
+			System.out.println(((TileTCRail) te).getType());
+		}
 		if (!world.isRemote && te != null && (te instanceof TileTCRail)) {
 			if (player != null && player.inventory != null && player.inventory.getCurrentItem() != null && (player.inventory.getCurrentItem().getItem() instanceof IToolWrench) && ((TileTCRail) te).getType() != null && ((TileTCRail) te).getType().equals(ItemTCRail.TrackTypes.SMALL_STRAIGHT.getLabel())) {
 				l++;

--- a/src/main/java/train/common/blocks/BlockTCRail.java
+++ b/src/main/java/train/common/blocks/BlockTCRail.java
@@ -130,9 +130,6 @@ public class BlockTCRail extends Block {
 	public boolean onBlockActivated(World world, int i, int j, int k, EntityPlayer player, int par6, float par7, float par8, float par9) {
 		TileEntity te = world.getTileEntity(i, j, k);
 		int l = world.getBlockMetadata(i, j, k);
-		if((te instanceof TileTCRail)){
-			System.out.println(((TileTCRail) te).getType());
-		}
 		if (!world.isRemote && te != null && (te instanceof TileTCRail)) {
 			if (player != null && player.inventory != null && player.inventory.getCurrentItem() != null && (player.inventory.getCurrentItem().getItem() instanceof IToolWrench) && ((TileTCRail) te).getType() != null && ((TileTCRail) te).getType().equals(ItemTCRail.TrackTypes.SMALL_STRAIGHT.getLabel())) {
 				l++;

--- a/src/main/java/train/common/tile/TileTCRail.java
+++ b/src/main/java/train/common/tile/TileTCRail.java
@@ -87,7 +87,7 @@ public class TileTCRail extends TileEntity {
 	}
 
 	public void setType(String type) {
-
+		worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
 		this.type = type;
 	}
 


### PR DESCRIPTION
On these commits I try to solve Train reverse.
-I allow client update for tileEntityBoggie (so extra hitbox on locomotives move).
- I found out that Train reverse when associated entity boggie derail. (due to the updateDistance() function). So I prevent the to derail en most of the cases, if they derail I made the all locomotive derail on the next turn.
- I didn't found any issue on normal track after the patch.
- On TC track train can derail on medium turn (over 180 km/h) or have weird behavior on medium switch with high speed.
