### PR TITLE
Fixed GUI Naming

### DIFF
--- a/src/main/java/train/common/entity/rollingStock/EntityFreightHopperUS.java
+++ b/src/main/java/train/common/entity/rollingStock/EntityFreightHopperUS.java
@@ -108,7 +108,7 @@ public class EntityFreightHopperUS extends Freight implements IInventory {
 
 	@Override
 	public String getInventoryName() {
-		return "Grain Hopper";
+		return "Freight Hopper";
 	}
 
 	@Override


### PR DESCRIPTION
Freight hopper is now no longer called Grain hopper and is instead
Freight Hopper
