### PR TITLE
Fixing GUI Naming Issue #2

### DIFF
--- a/src/main/java/train/common/entity/rollingStock/EntityLocoDieselCD742.java
+++ b/src/main/java/train/common/entity/rollingStock/EntityLocoDieselCD742.java
@@ -161,7 +161,7 @@ public class EntityLocoDieselCD742 extends DieselTrain {
 
 	@Override
 	public String getInventoryName() {
-		return "GP40";
+		return "CD742";
 	}
 
 	@Override


### PR DESCRIPTION
The CD742 was named in its GUI as the GP40 this has been corrected.
