### PR TITLE
Allow inserting fuel into Distil from the sides

### DIFF
--- a/src/main/java/train/common/tile/TileEntityDistil.java
+++ b/src/main/java/train/common/tile/TileEntityDistil.java
@@ -376,7 +376,9 @@ public class TileEntityDistil extends TileTraincraft implements IFluidHandler {
 
 	@Override
 	public boolean canInsertItem(int slot, ItemStack stack, int side){
-		return side != 0 && slot == 0;
+		if(side == 0) return false;          // bottom is extract only
+		else if(side == 1) return slot == 0; // insert input into top
+		else return slot == 1;               // insert fuel into sides
 	}
 
 	@Override


### PR DESCRIPTION
This matches vanilla Furnaces, which allow inputs in the top and fuel
items from the sides.