### PR TITLE
Improved Performance / reduced CPU-usage when checking for allowed items

### DIFF
--- a/src/main/java/train/common/core/handlers/ItemHandler.java
+++ b/src/main/java/train/common/core/handlers/ItemHandler.java
@@ -22,9 +22,6 @@ import java.util.ArrayList;
 
 public class ItemHandler {
 	
-	private static final ArrayList<ItemStack> planks = OreDictionary.getOres("plankWood");
-	private static final ArrayList<ItemStack> logs = OreDictionary.getOres("logWood");
-
 	public static boolean handleItems(Entity entity, ItemStack itemstack) {
 		if (itemstack != null) {
 			if (entity instanceof Freight) {
@@ -45,6 +42,11 @@ public class ItemHandler {
 	}
 
 	public static boolean handleFreight(Entity entity, ItemStack itemstack) {
+        int logWood = OreDictionary.getOreID("logWood");
+        int plankWood = OreDictionary.getOreID("plankWood");
+        if(itemstack == null) {
+            return false;
+        }
 		Block block = Block.getBlockFromItem(itemstack.getItem());
 		if (block == null) {
 			return false;
@@ -57,45 +59,20 @@ public class ItemHandler {
 		}
 		if (entity instanceof EntityFlatCarLogs_DB || entity instanceof EntityFreightWood
 				|| entity instanceof EntityFreightWood2) {
-			for (ItemStack log : logs) {
-				if (block == Block.getBlockFromItem(log.getItem())) {
-					return true;
-				}
-			}
+            return OreDictionary.getOreID(itemstack) == logWood;
 		}
 		if (entity instanceof EntityFlatCartWoodUS) {
-			for (ItemStack plank : planks) {
-				if (block == Block.getBlockFromItem(plank.getItem())) {
-					return true;
-				}
-			}
+            return OreDictionary.getOreID(itemstack) == plankWood;
 		}
 		if (entity instanceof EntityFreightCenterbeam_Wood_1 || entity instanceof EntityFreightCenterbeam_Wood_2) {
-			for (ItemStack log : logs) {
-				if (block == Block.getBlockFromItem(log.getItem())) {
-					return true;
-				}
-			}
-			for (ItemStack plank : planks) {
-				if (block == Block.getBlockFromItem(plank.getItem())) {
-					return true;
-				}
-			}
+            int isid = OreDictionary.getOreID(itemstack);
+            return isid == plankWood || isid == logWood;
 		}
 		if (entity instanceof EntityFreightOpenWagon || entity instanceof EntityFreightCartUS
 				|| entity instanceof EntityFreightClosed || entity instanceof EntityFreightGondola_DB
 				|| entity instanceof EntityFreightOpen2 || entity instanceof EntityFreightHopperUS) {
-			for (ItemStack log : logs) {
-				if (block == Block.getBlockFromItem(log.getItem())) {
-					return false;
-				}
-			}
-			for (ItemStack plank : planks) {
-				if (block == Block.getBlockFromItem(plank.getItem())) {
-					return false;
-				}
-			}
-			return true;
+            int isid = OreDictionary.getOreID(itemstack);
+            return !(isid == plankWood || isid == logWood);
 		}
 		if (entity instanceof EntityFlatCarRails_DB) {
 			if (block instanceof BlockRailBase) {
@@ -120,16 +97,7 @@ public class ItemHandler {
 	private static boolean cropStuff(ItemStack itemstack) {
 		String[] names = new String[] { "cropCorn", "cropRice", "seedRice", "seedCorn", "listAllseed" };
 		for (String name: names) {
-			if (isDict(name, itemstack)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	private static boolean isDict(String name, ItemStack itemstack) {
-		for (ItemStack item : OreDictionary.getOres(name)) {
-			if (itemstack.isItemEqual(item)) {
+			if (OreDictionary.getOreID(name) == OreDictionary.getOreID(itemstack)) {
 				return true;
 			}
 		}

--- a/src/main/java/train/common/core/handlers/ItemHandler.java
+++ b/src/main/java/train/common/core/handlers/ItemHandler.java
@@ -42,11 +42,11 @@ public class ItemHandler {
 	}
 
 	public static boolean handleFreight(Entity entity, ItemStack itemstack) {
-        int logWood = OreDictionary.getOreID("logWood");
-        int plankWood = OreDictionary.getOreID("plankWood");
-        if(itemstack == null) {
-            return false;
-        }
+		int logWood = OreDictionary.getOreID("logWood");
+		int plankWood = OreDictionary.getOreID("plankWood");
+		if(itemstack == null) {
+			return false;
+		}
 		Block block = Block.getBlockFromItem(itemstack.getItem());
 		if (block == null) {
 			return false;
@@ -59,20 +59,20 @@ public class ItemHandler {
 		}
 		if (entity instanceof EntityFlatCarLogs_DB || entity instanceof EntityFreightWood
 				|| entity instanceof EntityFreightWood2) {
-            return OreDictionary.getOreID(itemstack) == logWood;
+			return OreDictionary.getOreID(itemstack) == logWood;
 		}
 		if (entity instanceof EntityFlatCartWoodUS) {
-            return OreDictionary.getOreID(itemstack) == plankWood;
+			return OreDictionary.getOreID(itemstack) == plankWood;
 		}
 		if (entity instanceof EntityFreightCenterbeam_Wood_1 || entity instanceof EntityFreightCenterbeam_Wood_2) {
             int isid = OreDictionary.getOreID(itemstack);
-            return isid == plankWood || isid == logWood;
+			return isid == plankWood || isid == logWood;
 		}
 		if (entity instanceof EntityFreightOpenWagon || entity instanceof EntityFreightCartUS
 				|| entity instanceof EntityFreightClosed || entity instanceof EntityFreightGondola_DB
 				|| entity instanceof EntityFreightOpen2 || entity instanceof EntityFreightHopperUS) {
             int isid = OreDictionary.getOreID(itemstack);
-            return !(isid == plankWood || isid == logWood);
+			return !(isid == plankWood || isid == logWood);
 		}
 		if (entity instanceof EntityFlatCarRails_DB) {
 			if (block instanceof BlockRailBase) {


### PR DESCRIPTION
Hello,
I've modified the allowed-item-check for freight-cars a bit so that it's no longer necessary to loop over the complete log- / plank-list, but instead use a single hash map lookup.