### PR TITLE
Check if windmill stands free and can "see" the sky 

### DIFF
--- a/src/main/java/train/common/core/handlers/ConfigHandler.java
+++ b/src/main/java/train/common/core/handlers/ConfigHandler.java
@@ -30,6 +30,7 @@ public class ConfigHandler {
 	public static boolean CHUNK_LOADING;
 	public static boolean SHOW_POSSIBLE_COLORS;
 	public static int TRAINCRAFT_VILLAGER_ID;
+	public static int WINDMILL_CHECK_RADIUS;
 	public static boolean REAL_TRAIN_SPEED;
 	public static boolean RETROGEN_CHUNKS;
 	public static boolean	MAKE_MODPACKS_GREAT_AGAIN;
@@ -61,7 +62,7 @@ public class ConfigHandler {
 			RETROGEN_CHUNKS = cf.getBoolean("ENABLE_RETROGEN", CATEGORY_GENERAL, false, "This will generate ores in existing chunks prior to installing Traincraft 5. Do note that if this is off chunks that are loaded will not retrogen later, no matter what.");
 			MAKE_MODPACKS_GREAT_AGAIN = cf.getBoolean("MAKE_MODPACKS_GREAT_AGAIN", CATEGORY_GENERAL, false,
 					"This will disable some of Traincrafts easier recipes to balance Modpacks");
-
+            WINDMILL_CHECK_RADIUS = getInt("WINDMILL_CHECK_RADIUS", CATEGORY_GENERAL, 1, -1, 10, "This sets the radius for the can-see-the-sky-check area around the windmill. 0=only location of windmill, 1=3x3, 2=5x5 etc. Use -1 to turn of this check completely. DEFAULT: 1");
 
 			// /* Blocks */
 			// BlockIDs.assemblyTableI.blockID = cf.get(CATEGORY_BLOCK , "block_assemblytableI",

--- a/src/main/java/train/common/tile/TileWindMill.java
+++ b/src/main/java/train/common/tile/TileWindMill.java
@@ -12,6 +12,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import train.common.core.TrainModBlockUtil;
 import train.common.core.handlers.WorldEvents;
 import train.common.core.util.Energy;
+import train.common.core.handlers.ConfigHandler;
 
 import java.util.ArrayList;
 import java.util.Random;
@@ -91,16 +92,23 @@ public class TileWindMill extends Energy implements IEnergyProvider {
 			}
 
 			/**
-			 * Check every 6 seconds a 5x5 area around the windmill top-block if it can see the sky
-             * (possible make the area configureable in the config file)
+			 * Check every 6 seconds if a selectable area around the windmill top-block can see the sky
 			 */
             if(this.updateTicks % 120 == 0) {
-               this.standsOpen = 0;
-               for(int x=-2;x<3;x++)
-                 for(int z=-2;z<3;z++)
-                   if(!this.worldObj.canBlockSeeTheSky(this.xCoord + x, this.yCoord + 1, this.zCoord + z))
-                       this.standsOpen++;
-            }
+                this.standsOpen = 0;
+                int st = ConfigHandler.WINDMILL_CHECK_RADIUS;
+                if(st >= 0) {
+                   int en = st+1;
+                   louter:
+                   for(int x=-st;x<en;x++)
+                     for(int z=-st;z<en;z++)
+                       if(!this.worldObj.canBlockSeeTheSky(this.xCoord + x, this.yCoord + 1, this.zCoord + z))
+                       {
+                           this.standsOpen++;
+                           break louter;
+                       }
+                }
+            } 
 
 			/**
 			 * Calculate production using wind strength


### PR DESCRIPTION
It has bugged me that the windmill can be plugged into a 1x2 space in a complete occlusion and still produces power like standing on top of a (windy :)) hill.

There for I've added a can-see-sky check to the 5x5 area of blocks in the same y-level the windmill-rotor resides. The check takes place every 6 seconds once. Power is only generated if this complete area can see the sky.

I know, that's not a perfect solution, but it's in my opinion a fair trade-off of cpu-usage versus cheatyness. :)