### PR TITLE
remove proximity check when mob collides with trains

### DIFF
--- a/src/main/java/train/common/core/handlers/CollisionHandler.java
+++ b/src/main/java/train/common/core/handlers/CollisionHandler.java
@@ -337,7 +337,6 @@ public class CollisionHandler {
 
 		double d2 = MathHelper.abs_max(d, d1);
 
-		if (d2 <= 0.7D) {
 			d2 = MathHelper.sqrt_double(d2);
 			d /= d2;
 			d1 /= d2;
@@ -408,10 +407,8 @@ public class CollisionHandler {
 								}
 							
 						}
-						//						}
 
 					}
-				}
 			}
 
 		}


### PR DESCRIPTION
This commit should fix #228 for mobs. (not for the player)

Before we check if the entity pos is at less than 0.7 blocks of the rolling stock pos. So we never apply damage/push with the outer box.
I remove this check but maybe it have an other utility that I does not understand.