### PR TITLE
Path trackbluider inventory and allowed blocks

### DIFF
--- a/src/main/java/train/common/entity/rollingStock/EntityTracksBuilder.java
+++ b/src/main/java/train/common/entity/rollingStock/EntityTracksBuilder.java
@@ -597,15 +597,23 @@ public class EntityTracksBuilder extends EntityRollingStock implements IInventor
 	}
 
 	/** can this block be used as ballast */
-	private boolean canBeBallast(ItemStack stack) {
-		/*
-		 * if (stack != null && (stack.itemID == Block.planks.blockID || stack.itemID == Block.gravel.blockID || stack.itemID == Block.stone.blockID || stack.itemID == Block.brick.blockID || stack.itemID == Block.cobblestone.blockID || stack.itemID == Block.sandStone.blockID)) { return true; } */
-		//return false;
+	public static boolean canBeBallast(ItemStack stack) {
+		if(stack == null || stack.getItem() == null)
+			return false;
+		
+			// allow gravel and sand ...
+		if (stack.getItem() instanceof ItemBlock) {
+			Block block = Block.getBlockFromItem(stack.getItem());
+			if(block instanceof BlockFalling) {
+				return true;
+			}
+		}
+
 		return canBeTunnel(stack);
 	}
 
 	/** can this block be used for the tunnel */
-	private boolean canBeTunnel(ItemStack stack) {
+	public static boolean canBeTunnel(ItemStack stack) {
 		if (stack == null || stack.getItem() == null)
 			return false;
 		if (!(stack.getItem() instanceof ItemBlock))
@@ -616,8 +624,8 @@ public class EntityTracksBuilder extends EntityRollingStock implements IInventor
 				return false;
 			if(block.getRenderType()!=0)
 				return false;
-			/*if (block.isOpaqueCube())
-				return true;*/
+			if(block instanceof BlockFalling)
+				return false;
 			return true;
 		}
 		return false;

--- a/src/main/java/train/common/inventory/InventoryBuilder.java
+++ b/src/main/java/train/common/inventory/InventoryBuilder.java
@@ -9,6 +9,10 @@ import net.minecraft.inventory.Container;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import train.common.entity.rollingStock.EntityTracksBuilder;
+import train.common.inventory.slot.SlotBuilderBallast;
+import train.common.inventory.slot.SlotBuilderFuel;
+import train.common.inventory.slot.SlotBuilderRail;
+import train.common.inventory.slot.SlotBuilderTunnel;
 import train.common.slots.SpecialSlots;
 
 public class InventoryBuilder extends Container {
@@ -25,30 +29,30 @@ public class InventoryBuilder extends Container {
 		// int j = (width)/2;
 		int d = 0;
 
-		addSlotToContainer(new Slot(entityminecart, 0, 8 - d, 53));//fuel
-		addSlotToContainer(new Slot(entityminecart, 1, 8 - d, 73));//tracks
-		addSlotToContainer(new Slot(entityminecart, 2, 64 - d, 63));//underblock2
-		addSlotToContainer(new Slot(entityminecart, 3, 64 - d, 45));//underblock
-		addSlotToContainer(new Slot(entityminecart, 4, 46 - d, 8));
-		addSlotToContainer(new Slot(entityminecart, 5, 64 - d, 8));
-		addSlotToContainer(new Slot(entityminecart, 6, 82 - d, 8));
-		addSlotToContainer(new Slot(entityminecart, 7, 84 - d, 32));//tunnel block
+		addSlotToContainer(new SlotBuilderFuel(entityminecart,    0, 8 - d, 53));  	//fuel
+		addSlotToContainer(new SlotBuilderRail(entityminecart,    1, 8 - d, 73));	//tracks
+		addSlotToContainer(new SlotBuilderTunnel(entityminecart,  2, 64 - d, 63));	//underblock2
+		addSlotToContainer(new SlotBuilderBallast(entityminecart, 3, 64 - d, 45));	//underblock
+		addSlotToContainer(new SlotBuilderTunnel(entityminecart,  4, 46 - d, 8));	// roof ?
+		addSlotToContainer(new SlotBuilderTunnel(entityminecart,  5, 64 - d, 8));	// roof ?
+		addSlotToContainer(new SlotBuilderTunnel(entityminecart,  6, 82 - d, 8));	// roof ?
+		addSlotToContainer(new SlotBuilderTunnel(entityminecart,  7, 84 - d, 32));	//tunnel block
 
-		addSlotToContainer(new Slot(entityminecart, 8, 8 - d, 98));//track buffer
-		addSlotToContainer(new Slot(entityminecart, 9, 8 - d, 116));//track buffer
-		addSlotToContainer(new Slot(entityminecart, 10, 8 - d, 134));//track buffer
+		addSlotToContainer(new SlotBuilderRail(entityminecart, 8, 8 - d, 98));		//track buffer
+		addSlotToContainer(new SlotBuilderRail(entityminecart, 9, 8 - d, 116));		//track buffer
+		addSlotToContainer(new SlotBuilderRail(entityminecart, 10, 8 - d, 134));	//track buffer
 
-		addSlotToContainer(new Slot(entityminecart, 11, 43 - d, 87));//under block buffer
-		addSlotToContainer(new Slot(entityminecart, 12, 43 - d, 105));//under block buffer
-		addSlotToContainer(new Slot(entityminecart, 13, 43 - d, 123));//under block buffer
+		addSlotToContainer(new SlotBuilderBallast(entityminecart, 11, 43 - d, 87));	//under block buffer
+		addSlotToContainer(new SlotBuilderBallast(entityminecart, 12, 43 - d, 105));//under block buffer
+		addSlotToContainer(new SlotBuilderBallast(entityminecart, 13, 43 - d, 123));//under block buffer
 
-		addSlotToContainer(new Slot(entityminecart, 14, 64 - d, 88));//under block2 buffer
-		addSlotToContainer(new Slot(entityminecart, 15, 64 - d, 106));//under block2 buffer
-		addSlotToContainer(new Slot(entityminecart, 16, 64 - d, 124));//under block2 buffer
+		addSlotToContainer(new SlotBuilderTunnel(entityminecart, 14, 64 - d, 88));	//under block2 buffer
+		addSlotToContainer(new SlotBuilderTunnel(entityminecart, 15, 64 - d, 106));	//under block2 buffer
+		addSlotToContainer(new SlotBuilderTunnel(entityminecart, 16, 64 - d, 124));	//under block2 buffer
 
-		addSlotToContainer(new Slot(entityminecart, 17, 84 - d, 57));//tunnel block buffer
-		addSlotToContainer(new Slot(entityminecart, 18, 84 - d, 75));//tunnel block buffer
-		addSlotToContainer(new Slot(entityminecart, 19, 84 - d, 93));//tunnel block buffer
+		addSlotToContainer(new SlotBuilderTunnel(entityminecart, 17, 84 - d, 57));	//tunnel block buffer
+		addSlotToContainer(new SlotBuilderTunnel(entityminecart, 18, 84 - d, 75));	//tunnel block buffer
+		addSlotToContainer(new SlotBuilderTunnel(entityminecart, 19, 84 - d, 93));	//tunnel block buffer
 
 		int i = 20;
 		for (int j = 0; j < loco.numBuilderSlots; j++) {
@@ -93,14 +97,17 @@ public class InventoryBuilder extends Container {
 
 		ItemStack itemstack = null;
 		Slot slot = (Slot) inventorySlots.get(i);
+
 		if (slot != null && slot.getHasStack()) {
 			ItemStack itemstack1 = slot.getStack();
 			itemstack = itemstack1.copy();
+				// move to player inventory
 			if (i <= inventorySize) {
 				if (!mergeItemStack(itemstack1, inventorySize, inventorySlots.size(), true)) {
 					return null;
 				}
 			}
+				// move to builder inventory
 			else if (!mergeItemStack(itemstack1, 0, 20, false)) {
 				return null;
 			}
@@ -111,8 +118,105 @@ public class InventoryBuilder extends Container {
 				slot.onSlotChanged();
 			}
 		}
+
 		return itemstack;
 	}
+
+    /**
+     * merges provided ItemStack with the first avaliable one in the container/player inventory
+     */
+	@Override
+    protected boolean mergeItemStack(ItemStack stack, int first, int last, boolean isPlayer)
+    {
+        boolean flag1 = false;
+        int k = first;
+
+        if (isPlayer)
+        {
+            k = last - 1;
+        }
+
+        Slot slot;
+        ItemStack itemstack1;
+
+        // search already used stacks
+        if (stack.isStackable())
+        {
+            while (stack.stackSize > 0 && (!isPlayer && k < last || isPlayer && k >= first))
+            {
+                slot = (Slot)this.inventorySlots.get(k);
+                itemstack1 = slot.getStack();
+
+                if (itemstack1 != null && itemstack1.getItem() == stack.getItem() && (!stack.getHasSubtypes() || stack.getItemDamage() == itemstack1.getItemDamage()) && ItemStack.areItemStackTagsEqual(stack, itemstack1))
+                {
+                    int l = itemstack1.stackSize + stack.stackSize;
+
+                    if (l <= stack.getMaxStackSize())
+                    {
+                        stack.stackSize = 0;
+                        itemstack1.stackSize = l;
+                        slot.onSlotChanged();
+                        flag1 = true;
+                    }
+                    else if (itemstack1.stackSize < stack.getMaxStackSize())
+                    {
+                        stack.stackSize -= stack.getMaxStackSize() - itemstack1.stackSize;
+                        itemstack1.stackSize = stack.getMaxStackSize();
+                        slot.onSlotChanged();
+                        flag1 = true;
+                    }
+                }
+
+                if (isPlayer)
+                {
+                    --k;
+                }
+                else
+                {
+                    ++k;
+                }
+            }
+        }
+
+        // search empty stacks
+        if (stack.stackSize > 0)
+        {
+            if (isPlayer)
+            {
+                k = last - 1;
+            }
+            else
+            {
+                k = first;
+            }
+
+            while (!isPlayer && k < last || isPlayer && k >= first)
+            {
+                slot = (Slot)this.inventorySlots.get(k);
+                itemstack1 = slot.getStack();
+
+                if (itemstack1 == null && slot.isItemValid(stack))
+                {
+                    slot.putStack(stack.copy());
+                    slot.onSlotChanged();
+                    stack.stackSize = 0;
+                    flag1 = true;
+                    break;
+                }
+
+                if (isPlayer)
+                {
+                    --k;
+                }
+                else
+                {
+                    ++k;
+                }
+            }
+        }
+
+        return flag1;
+    }
 
 	private EntityTracksBuilder loco;
 	private InventoryPlayer player;

--- a/src/main/java/train/common/inventory/slot/SlotBuilderBallast.java
+++ b/src/main/java/train/common/inventory/slot/SlotBuilderBallast.java
@@ -1,0 +1,29 @@
+package train.common.inventory.slot;
+
+import mods.railcraft.api.core.items.ITrackItem;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockRailBase;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import train.common.entity.rollingStock.EntityTracksBuilder;
+import train.common.items.ItemTCRail;
+import train.common.items.ItemTCRail.TrackTypes;
+
+public class SlotBuilderBallast extends Slot {
+
+	public SlotBuilderBallast(IInventory inv, int id, int x, int y) {
+		super(inv, id, x, y);
+	}
+	
+    /**
+     * Check if the stack is a valid item for this slot.
+     */
+    public boolean isItemValid(ItemStack stack)
+    {
+        return EntityTracksBuilder.canBeBallast(stack);
+    }
+
+}

--- a/src/main/java/train/common/inventory/slot/SlotBuilderFuel.java
+++ b/src/main/java/train/common/inventory/slot/SlotBuilderFuel.java
@@ -1,0 +1,29 @@
+package train.common.inventory.slot;
+
+import mods.railcraft.api.core.items.ITrackItem;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockRailBase;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import train.common.core.handlers.FuelHandler;
+import train.common.items.ItemTCRail;
+import train.common.items.ItemTCRail.TrackTypes;
+
+public class SlotBuilderFuel extends Slot {
+
+	public SlotBuilderFuel(IInventory inv, int id, int x, int y) {
+		super(inv, id, x, y);
+	}
+	
+    /**
+     * Check if the stack is a valid item for this slot.
+     */
+    public boolean isItemValid(ItemStack stack)
+    {
+        return FuelHandler.steamFuelLast(stack) > 0;
+    }
+
+}

--- a/src/main/java/train/common/inventory/slot/SlotBuilderRail.java
+++ b/src/main/java/train/common/inventory/slot/SlotBuilderRail.java
@@ -1,0 +1,54 @@
+package train.common.inventory.slot;
+
+import mods.railcraft.api.core.items.ITrackItem;
+import mods.railcraft.api.tracks.RailTools;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockRailBase;
+import net.minecraft.init.Blocks;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import train.common.items.ItemTCRail;
+import train.common.items.ItemTCRail.TrackTypes;
+
+public class SlotBuilderRail extends Slot {
+
+	public SlotBuilderRail(IInventory inv, int id, int x, int y) {
+		super(inv, id, x, y);
+	}
+	
+    /**
+     * Check if the stack is a valid item for this slot.
+     * The builder should accept:
+     *  - rail, detector rail, golden rail
+     *  - iron, steel (why ?)
+     *  - small straight TC rail
+     */
+    public boolean isItemValid(ItemStack stack)
+    {
+    	if(stack == null)
+    		return false;
+    	
+    	Item item = stack.getItem();
+    	
+    		// check TC rail
+		if(item instanceof ItemTCRail) {
+    		return ((ItemTCRail) item).getTrackType() == TrackTypes.SMALL_STRAIGHT;
+		}
+		
+			// check others railcraft items
+    	if(RailTools.isTrackItem(stack)) {
+    		return true;
+    	}
+    	    	
+    	if(item instanceof ItemBlock) {
+    		Block  block = ((ItemBlock) stack.getItem()).field_150939_a;
+    		return block == Blocks.rail || block == Blocks.golden_rail || block == Blocks.detector_rail;
+    	}
+    	
+        return false;
+    }
+
+}

--- a/src/main/java/train/common/inventory/slot/SlotBuilderTunnel.java
+++ b/src/main/java/train/common/inventory/slot/SlotBuilderTunnel.java
@@ -1,0 +1,29 @@
+package train.common.inventory.slot;
+
+import mods.railcraft.api.core.items.ITrackItem;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockRailBase;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import train.common.entity.rollingStock.EntityTracksBuilder;
+import train.common.items.ItemTCRail;
+import train.common.items.ItemTCRail.TrackTypes;
+
+public class SlotBuilderTunnel extends Slot {
+
+	public SlotBuilderTunnel(IInventory inv, int id, int x, int y) {
+		super(inv, id, x, y);
+	}
+	
+    /**
+     * Check if the stack is a valid item for this slot.
+     */
+    public boolean isItemValid(ItemStack stack)
+    {
+        return EntityTracksBuilder.canBeTunnel(stack);
+    }
+
+}

--- a/src/main/java/train/common/items/ItemTCRail.java
+++ b/src/main/java/train/common/items/ItemTCRail.java
@@ -1970,5 +1970,9 @@ public class ItemTCRail extends ItemPart {
 	public void addInformation(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, List par3List, boolean par4) {
 		par3List.add("\u00a77" + type.getTooltip());
 	}
+
+	public TrackTypes getTrackType() {
+		return this.type;
+	}
 }
 


### PR DESCRIPTION
Trackbuilder inventory slots now only accept valids items.

Fuel slot is restricted to burnable items
Tracks slots only accept:
  - Minecraft rail, golden rail, detector rails
  - TC small straigth rail
  - railcraft rails

others slots except underblock does not accept falling blocks.

related to #480 again