### PR TITLE
some bug fixes for crafting system, fix spelling

### DIFF
--- a/src/main/java/ebf/tim/blocks/TileEntityStorage.java
+++ b/src/main/java/ebf/tim/blocks/TileEntityStorage.java
@@ -34,17 +34,17 @@ public class TileEntityStorage extends TileRenderFacing implements IInventory, I
         int s=400;
         inventory= new ArrayList<>();
         if(block.getUnlocalizedName().equals("tile.block.traintable")){
-            //inventory grid
+            //inventory grid (left grid)
             for (int l = 0; l < 3; ++l) {
                 for (int i1 = 0; i1 < 3; ++i1) {
-                    inventory.add(new ItemStackSlot(this,s).setCoords( 30 + i1 * 18, 17 + l * 18));
+                    inventory.add(new ItemStackSlot(this,s).setCoords( 30 + i1 * 18, 17 + l * 18).setCraftingInput(true));
                     s++;
                 }
             }
-            //tile entity's crafting grid
+            //tile entity's crafting grid (right hand grid)
             for (int l = 0; l < 3; ++l) {
                 for (int i1 = 0; i1 < 3; ++i1) {
-                    inventory.add(new ItemStackSlot(this,s).setCoords( 106 + i1 * 18, 17 + l * 18).setCraftingInput(true));
+                    inventory.add(new ItemStackSlot(this,s).setCoords( 106 + i1 * 18, 17 + l * 18));
                     s++;
                 }
             }

--- a/src/main/java/ebf/tim/entities/GenericRailTransport.java
+++ b/src/main/java/ebf/tim/entities/GenericRailTransport.java
@@ -2205,7 +2205,7 @@ public class GenericRailTransport extends EntityMinecart implements IEntityAddit
      * example:
      * return new ItemStack[]{new ItemStack(Blocks.dirt, 2), new ItemStack(Blocks.glass,1), etc};
      * array must contain 9 values. may not return null.*/
-    public ItemStack[] getRecipie(){return new ItemStack[]{
+    public ItemStack[] getRecipe(){return new ItemStack[]{
             new ItemStack(Blocks.dirt),null,null,null,null,null,null,null,null
     };}
 

--- a/src/main/java/ebf/tim/registry/TiMGenericRegistry.java
+++ b/src/main/java/ebf/tim/registry/TiMGenericRegistry.java
@@ -250,20 +250,20 @@ public class TiMGenericRegistry {
                     registry.transportName().replace(" ","") + ".entity",
                     registryPosition, TrainsInMotion.instance, 1600, 3, true);
             GameRegistry.registerItem(registry.getCartItem().getItem(), registry.getCartItem().getItem().getUnlocalizedName());
-            if(registry.getRecipie()!=null) {
+            if(registry.getRecipe()!=null) {
                 if (CommonProxy.recipesInMods.containsKey(MODID)) {
-                    CommonProxy.recipesInMods.get(MODID).add(getRecipe(registry.getRecipie(), registry.getCartItem()));
+                    CommonProxy.recipesInMods.get(MODID).add(getRecipe(registry.getRecipe(), registry.getCartItem()));
                 } else {
                     CommonProxy.recipesInMods.put(MODID, new ArrayList<Recipe>());
-                    CommonProxy.recipesInMods.get(MODID).add(getRecipe(registry.getRecipie(), registry.getCartItem()));
+                    CommonProxy.recipesInMods.get(MODID).add(getRecipe(registry.getRecipe(), registry.getCartItem()));
                 }
             }
             if(TrainsInMotion.proxy.isClient() && ClientProxy.hdTransportItems){
                 MinecraftForgeClient.registerItemRenderer(registry.getCartItem().getItem(), ebf.tim.items.CustomItemModel.instance);
             }
             registry.registerSkins();
-            if(registry.getRecipie()!=null){
-                RecipeManager.registerRecipe(registry.getRecipie(), registry.getCartItem());
+            if(registry.getRecipe()!=null){
+                RecipeManager.registerRecipe(registry.getRecipe(), registry.getCartItem());
             }
             ItemCraftGuide.itemEntries.add(registry.getClass());
             if(TrainsInMotion.proxy.isClient()) {

--- a/src/main/java/ebf/tim/utility/ItemStackSlot.java
+++ b/src/main/java/ebf/tim/utility/ItemStackSlot.java
@@ -205,11 +205,11 @@ public class ItemStackSlot extends Slot {
         if((isCraftingInput || isCraftingOutput) && hostInventory instanceof TileEntityStorage) {
             int page = ((TileEntityStorage)hostInventory).outputPage;
             switch (((TileEntityStorage)hostInventory).storageType) {
-                case 1: {
+                case 1: { //train crafting
                     List<ItemStack> slots = RecipeManager.getResult(RecipeManager.getTransportRecipe(hostInventory));
                     if(slots==null){
                         for (int i = 0; i < 9; i++) {
-                            putStackInSlot(hostSlots,400 + i, null);
+                            putStackInSlot(hostSlots,409 + i, null);
                         }
                     } else {
                         if(slots.size()<10) {
@@ -234,7 +234,7 @@ public class ItemStackSlot extends Slot {
                     }
                     break;
                 }
-                case 0: {
+                case 0: { //track crafting
                     putStackInSlot(hostSlots,406, RecipeManager.railRecipe(hostInventory));
                     break;
                 }
@@ -395,7 +395,7 @@ public class ItemStackSlot extends Slot {
 
     /**
      * Helper method to put a stack in the slot.
-     * @deprecated use {@link #setSlotContents(ItemStack)} instead because it can return whether ot not it actually did it.
+     * @deprecated use {@link #setSlotContents(ItemStack, List)} instead because it can return whether ot not it actually did it.
      */
     @Override
     @Deprecated

--- a/src/main/java/ebf/tim/utility/Recipe.java
+++ b/src/main/java/ebf/tim/utility/Recipe.java
@@ -127,18 +127,21 @@ public class Recipe {
 
 
 
-    public boolean recipeInputMatches(List<List<ItemStack>> stacks){
+    public boolean recipeInputMatches(List<List<ItemStack>> stacks){ //is this correctly comparing when null is present in the stacks parameter?
         int i=0;
         boolean slotClear=false;
-        for(List<ItemStack> slot : input){//itterate the slots
-            if (stacks.size() <= i){return false;}
-            for(ItemStack s : slot){//itterate the recipe values
-                for(ItemStack stak : stacks.get(i)) { //itterate the checked stack values
-                    if(s==null && stak==null) {
+        for(List<ItemStack> slot : input){//iterate through the recipe's ingredients
+            if (stacks.size() <= i){return false;} //recipes are variable length, terminate if it gets to the end without success
+            for(ItemStack s : slot){//iterate through the items that fit as the recipe's ingredient
+                for(ItemStack stak : stacks.get(i)) { //iterate the items that fit as that ingredient in stacks
+                    if(s==null && stak==null) { //if both are null, that is ok, it matches
                         slotClear=true;
                         break;
-                    } else if(s==null || stak==null){
-                        continue;
+                    } else if(s==null || stak==null){ //one is null when the other isn't.
+                        //Can either s or stak be null when there is a possible ingredient?
+                        //  I think not, so this means the ingredients don't match. Return false.
+                        //  Already accounted for both null, so this is safe to return false.
+                        return false;
                     }
                     if ((s.getItem() == stak.getItem() && s.stackSize <= stak.stackSize)) {
                         slotClear=true;

--- a/src/main/java/ebf/tim/utility/RecipeManager.java
+++ b/src/main/java/ebf/tim/utility/RecipeManager.java
@@ -30,6 +30,7 @@ public class RecipeManager {
         , (recipe.topLeft()==null || recipe.topLeft().size()==0 || recipe.topLeft().get(0)==null?"null": recipe.topLeft().get(0).getDisplayName()),
                 recipe.getresult().get(0).getDisplayName());*/
 
+        // adds a result to the recipe if it already exists, rather than creating a new one.
         for(Recipe r : recipeList){
             if(r.recipeInputMatches(recipe.input)){
                 r.addResults(recipe.result);

--- a/src/main/java/train/entity/rollingStock/EntityBUnitDD35.java
+++ b/src/main/java/train/entity/rollingStock/EntityBUnitDD35.java
@@ -69,7 +69,7 @@ public class EntityBUnitDD35 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 8), new ItemStack(ItemIDs.steelframe.item, 3),
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 2), new ItemStack(ItemIDs.steelcab.item, 1),

--- a/src/main/java/train/entity/rollingStock/EntityBUnitEMDF3.java
+++ b/src/main/java/train/entity/rollingStock/EntityBUnitEMDF3.java
@@ -79,7 +79,7 @@ public class EntityBUnitEMDF3 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 null, null, null, new ItemStack(ItemIDs.electmotor.item, 4), new ItemStack(ItemIDs.dieselengine.item, 6), new ItemStack(ItemIDs.generator.item, 4)        };

--- a/src/main/java/train/entity/rollingStock/EntityBUnitEMDF7.java
+++ b/src/main/java/train/entity/rollingStock/EntityBUnitEMDF7.java
@@ -79,7 +79,7 @@ public class EntityBUnitEMDF7 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 null, null, null, new ItemStack(ItemIDs.electmotor.item, 4), new ItemStack(ItemIDs.dieselengine.item, 6), new ItemStack(ItemIDs.generator.item, 4)        };

--- a/src/main/java/train/entity/rollingStock/EntityBoxCartPRR.java
+++ b/src/main/java/train/entity/rollingStock/EntityBoxCartPRR.java
@@ -68,7 +68,7 @@ public class EntityBoxCartPRR extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 5), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 3),
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Blocks.chest, 2)        };

--- a/src/main/java/train/entity/rollingStock/EntityBoxCartUS.java
+++ b/src/main/java/train/entity/rollingStock/EntityBoxCartUS.java
@@ -99,7 +99,7 @@ public class EntityBoxCartUS extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 5), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Blocks.chest, 2)        };

--- a/src/main/java/train/entity/rollingStock/EntityBulkheadFlatCart.java
+++ b/src/main/java/train/entity/rollingStock/EntityBulkheadFlatCart.java
@@ -71,7 +71,7 @@ public class EntityBulkheadFlatCart extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 4), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2),
                 new ItemStack(ItemIDs.steel.item, 4), null, null, null, null, null        };

--- a/src/main/java/train/entity/rollingStock/EntityCaboose.java
+++ b/src/main/java/train/entity/rollingStock/EntityCaboose.java
@@ -69,7 +69,7 @@ public class EntityCaboose extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 6), new ItemStack(ItemIDs.woodenBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 2),
                 new ItemStack(Items.stick, 2), null, new ItemStack(ItemIDs.woodenCab.item, 1),

--- a/src/main/java/train/entity/rollingStock/EntityCaboose3.java
+++ b/src/main/java/train/entity/rollingStock/EntityCaboose3.java
@@ -69,7 +69,7 @@ public class EntityCaboose3 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 2), new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.ironFrame.item, 2),
                 new ItemStack(Items.iron_ingot, 2), null, new ItemStack(ItemIDs.woodenCab.item, 1),

--- a/src/main/java/train/entity/rollingStock/EntityCabooseLogging.java
+++ b/src/main/java/train/entity/rollingStock/EntityCabooseLogging.java
@@ -71,7 +71,7 @@ public class EntityCabooseLogging extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 3), new ItemStack(ItemIDs.woodenBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 2),
                 new ItemStack(Items.iron_ingot, 1), null, null, null, null, new ItemStack(Blocks.crafting_table, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityCabooseLoggingPRR.java
+++ b/src/main/java/train/entity/rollingStock/EntityCabooseLoggingPRR.java
@@ -73,7 +73,7 @@ public class EntityCabooseLoggingPRR extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 5), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2),
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Blocks.crafting_table, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityCabooseWorkCart.java
+++ b/src/main/java/train/entity/rollingStock/EntityCabooseWorkCart.java
@@ -69,7 +69,7 @@ public class EntityCabooseWorkCart extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 6), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2),
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Blocks.crafting_table, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityFlatCarLogs_DB.java
+++ b/src/main/java/train/entity/rollingStock/EntityFlatCarLogs_DB.java
@@ -70,7 +70,7 @@ public class EntityFlatCarLogs_DB extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 5), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2),
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Blocks.log, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityFlatCarRails_DB.java
+++ b/src/main/java/train/entity/rollingStock/EntityFlatCarRails_DB.java
@@ -70,7 +70,7 @@ public class EntityFlatCarRails_DB extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 5), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2),
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Blocks.rail, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityFlatCar_DB.java
+++ b/src/main/java/train/entity/rollingStock/EntityFlatCar_DB.java
@@ -69,7 +69,7 @@ public class EntityFlatCar_DB extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 5), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2),
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, null        };

--- a/src/main/java/train/entity/rollingStock/EntityFlatCart.java
+++ b/src/main/java/train/entity/rollingStock/EntityFlatCart.java
@@ -69,7 +69,7 @@ public class EntityFlatCart extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 3), new ItemStack(ItemIDs.woodenBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 2), 
                 new ItemStack(Items.stick, 2), null, null, null, null, null        };

--- a/src/main/java/train/entity/rollingStock/EntityFlatCartSU.java
+++ b/src/main/java/train/entity/rollingStock/EntityFlatCartSU.java
@@ -67,7 +67,7 @@ public class EntityFlatCartSU extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 6), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, null        };

--- a/src/main/java/train/entity/rollingStock/EntityFlatCartUS.java
+++ b/src/main/java/train/entity/rollingStock/EntityFlatCartUS.java
@@ -68,7 +68,7 @@ public class EntityFlatCartUS extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 3), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, null        };

--- a/src/main/java/train/entity/rollingStock/EntityFlatCartWoodUS.java
+++ b/src/main/java/train/entity/rollingStock/EntityFlatCartWoodUS.java
@@ -68,7 +68,7 @@ public class EntityFlatCartWoodUS extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 6), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, null        };

--- a/src/main/java/train/entity/rollingStock/EntityFreight100TonHopper.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreight100TonHopper.java
@@ -74,7 +74,7 @@ public class EntityFreight100TonHopper extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 6), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 3), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Blocks.hopper, 3)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightASTFAutorack.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightASTFAutorack.java
@@ -67,7 +67,7 @@ public class EntityFreightASTFAutorack extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 4), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 6), 
                 new ItemStack(ItemIDs.steel.item, 4), null, null, null, null, null        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightBaggageMILW.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightBaggageMILW.java
@@ -68,7 +68,7 @@ public class EntityFreightBaggageMILW extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 1), 
                 null, null, null, null, null, new ItemStack(Blocks.chest, 2)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightBamboo.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightBamboo.java
@@ -98,7 +98,7 @@ public class EntityFreightBamboo extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.woodenBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 1), 
                 null, null, null, null, null, new ItemStack(Blocks.chest, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightCart.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightCart.java
@@ -69,7 +69,7 @@ public class EntityFreightCart extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 6), new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.ironFrame.item, 2), 
                 new ItemStack(Items.iron_ingot, 2), null, null, null, null, new ItemStack(Blocks.chest, 2)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightCart2.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightCart2.java
@@ -69,7 +69,7 @@ public class EntityFreightCart2 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 6), new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.ironFrame.item, 2), 
                 new ItemStack(Items.iron_ingot, 2), null, null, null, null, new ItemStack(Blocks.chest, 2)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightCartL.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightCartL.java
@@ -70,7 +70,7 @@ public class EntityFreightCartL extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 4), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Blocks.chest, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightCartSmall.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightCartSmall.java
@@ -69,7 +69,7 @@ public class EntityFreightCartSmall extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 6), new ItemStack(ItemIDs.woodenBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 2), 
                 new ItemStack(Items.stick, 2), null, null, null, null, new ItemStack(Blocks.chest, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightCartUS.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightCartUS.java
@@ -99,7 +99,7 @@ public class EntityFreightCartUS extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 6), new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.ironFrame.item, 2), 
                 new ItemStack(Items.iron_ingot, 2), null, null, null, null, new ItemStack(Blocks.hopper, 2)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightCenterbeam_Empty.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightCenterbeam_Empty.java
@@ -68,7 +68,7 @@ public class EntityFreightCenterbeam_Empty extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 6), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Blocks.planks, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightCenterbeam_Wood_1.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightCenterbeam_Wood_1.java
@@ -68,7 +68,7 @@ public class EntityFreightCenterbeam_Wood_1 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 6), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Blocks.planks, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightCenterbeam_Wood_2.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightCenterbeam_Wood_2.java
@@ -68,7 +68,7 @@ public class EntityFreightCenterbeam_Wood_2 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 6), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Blocks.planks, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightClosed.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightClosed.java
@@ -69,7 +69,7 @@ public class EntityFreightClosed extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 4), new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.ironFrame.item, 4), 
                 new ItemStack(Items.iron_ingot, 2), null, null, null, null, new ItemStack(Blocks.chest, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightDenverRioGrande.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightDenverRioGrande.java
@@ -74,7 +74,7 @@ public class EntityFreightDenverRioGrande extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.chest, 4), new ItemStack(ItemIDs.ironBogie.item, 4), new ItemStack(ItemIDs.woodenFrame.item, 3), 
                 null, null, new ItemStack(ItemIDs.woodenCab.item, 3), 

--- a/src/main/java/train/entity/rollingStock/EntityFreightDepressedFlatbed.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightDepressedFlatbed.java
@@ -71,7 +71,7 @@ public class EntityFreightDepressedFlatbed extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 3), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, null        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightGS4_Baggage.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightGS4_Baggage.java
@@ -88,7 +88,7 @@ public class EntityFreightGS4_Baggage extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 1), 
                 null, null, null, null, null, new ItemStack(Blocks.chest, 2)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightGTNG.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightGTNG.java
@@ -68,7 +68,7 @@ public class EntityFreightGTNG extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 6), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Blocks.hopper, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightGermanPost.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightGermanPost.java
@@ -72,7 +72,7 @@ public class EntityFreightGermanPost extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 1), 
                 null, null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityFreightGondola_DB.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightGondola_DB.java
@@ -70,7 +70,7 @@ public class EntityFreightGondola_DB extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 5), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Blocks.hopper, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightGrain.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightGrain.java
@@ -68,7 +68,7 @@ public class EntityFreightGrain extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 5), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Items.wheat, 3)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightHeavyweight.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightHeavyweight.java
@@ -68,7 +68,7 @@ public class EntityFreightHeavyweight extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 4), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Blocks.chest, 2)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightHeavyweightBaggage.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightHeavyweightBaggage.java
@@ -70,7 +70,7 @@ public class EntityFreightHeavyweightBaggage extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 4), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Blocks.chest, 2)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightHopperUS.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightHopperUS.java
@@ -90,7 +90,7 @@ public class EntityFreightHopperUS extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 5), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Items.wheat, 3)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightIceWagon.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightIceWagon.java
@@ -68,7 +68,7 @@ public class EntityFreightIceWagon extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.woodenBogie.item, 2), new ItemStack(ItemIDs.ironFrame.item, 1), 
                 new ItemStack(Items.iron_ingot, 2), null, null, null, null, new ItemStack(Items.snowball, 9)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightKClassRailBox.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightKClassRailBox.java
@@ -70,7 +70,7 @@ public class EntityFreightKClassRailBox extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 5), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Items.dye, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightLongCoveredHopper.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightLongCoveredHopper.java
@@ -80,7 +80,7 @@ public class EntityFreightLongCoveredHopper extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 5), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Items.dye, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightMinetrain.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightMinetrain.java
@@ -69,7 +69,7 @@ public class EntityFreightMinetrain extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Items.iron_ingot, 2), new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.ironFrame.item, 1), 
                 new ItemStack(Items.iron_ingot, 2), null, null, null, null, new ItemStack(Blocks.chest, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightOpen2.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightOpen2.java
@@ -69,7 +69,7 @@ public class EntityFreightOpen2 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 2), new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.ironFrame.item, 2), 
                 new ItemStack(Items.iron_ingot, 2), null, null, null, null, new ItemStack(Blocks.hopper, 2)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightOpenWagon.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightOpenWagon.java
@@ -68,7 +68,7 @@ public class EntityFreightOpenWagon extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 5), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Blocks.hopper, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightShortCoveredHopper.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightShortCoveredHopper.java
@@ -74,7 +74,7 @@ public class EntityFreightShortCoveredHopper extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 5), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Items.dye, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightSlateWagon.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightSlateWagon.java
@@ -68,7 +68,7 @@ public class EntityFreightSlateWagon extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.woodenBogie.item, 2), new ItemStack(ItemIDs.ironFrame.item, 1), 
                 new ItemStack(Items.iron_ingot, 2), null, null, null, null, new ItemStack(Items.coal, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightTrailer.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightTrailer.java
@@ -90,7 +90,7 @@ public class EntityFreightTrailer extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 5), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Blocks.chest, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightWagenDB.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightWagenDB.java
@@ -72,7 +72,7 @@ public class EntityFreightWagenDB extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 5), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Blocks.chest, 2)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightWellcar.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightWellcar.java
@@ -98,7 +98,7 @@ public class EntityFreightWellcar extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 5), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Blocks.chest, 2)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightWood.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightWood.java
@@ -69,7 +69,7 @@ public class EntityFreightWood extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 6), new ItemStack(ItemIDs.woodenBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 2), 
                 new ItemStack(Items.stick, 2), null, null, null, null, new ItemStack(Blocks.log, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityFreightWood2.java
+++ b/src/main/java/train/entity/rollingStock/EntityFreightWood2.java
@@ -69,7 +69,7 @@ public class EntityFreightWood2 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 3), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.ironFrame.item, 1), 
                 new ItemStack(Items.iron_ingot, 2), null, null, null, null, new ItemStack(Blocks.log, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityGWRBrakeVan.java
+++ b/src/main/java/train/entity/rollingStock/EntityGWRBrakeVan.java
@@ -68,7 +68,7 @@ public class EntityGWRBrakeVan extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.crafting_table, 1), new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 1), 
                 new ItemStack(Blocks.planks, 8), null, new ItemStack(ItemIDs.woodenCab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityMailWagen_DB.java
+++ b/src/main/java/train/entity/rollingStock/EntityMailWagen_DB.java
@@ -68,7 +68,7 @@ public class EntityMailWagen_DB extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 5), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Blocks.crafting_table, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityPassenger2.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassenger2.java
@@ -69,7 +69,7 @@ public class EntityPassenger2 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 6), new ItemStack(ItemIDs.woodenBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 2), 
                 new ItemStack(Items.stick, 2), null, new ItemStack(ItemIDs.woodenCab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityPassenger5.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassenger5.java
@@ -69,7 +69,7 @@ public class EntityPassenger5 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityPassenger7.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassenger7.java
@@ -69,7 +69,7 @@ public class EntityPassenger7 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 2), new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.ironFrame.item, 2), 
                 new ItemStack(Items.iron_ingot, 2), null, new ItemStack(ItemIDs.ironCab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityPassengerAdler.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassengerAdler.java
@@ -70,7 +70,7 @@ public class EntityPassengerAdler extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Items.iron_ingot, 1), new ItemStack(ItemIDs.woodenBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 2), 
                 new ItemStack(Items.iron_ingot, 1), null, new ItemStack(ItemIDs.woodenCab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityPassengerBamboo.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassengerBamboo.java
@@ -97,7 +97,7 @@ public class EntityPassengerBamboo extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.woodenBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 1), 
                 null, null, null, null, null, null        };

--- a/src/main/java/train/entity/rollingStock/EntityPassengerBlue.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassengerBlue.java
@@ -83,7 +83,7 @@ public class EntityPassengerBlue extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 5), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityPassengerDBOriental.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassengerDBOriental.java
@@ -73,7 +73,7 @@ public class EntityPassengerDBOriental extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 6), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 2), 
                 new ItemStack(Items.stick, 2), null, new ItemStack(ItemIDs.woodenCab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityPassengerDenverRioGrande.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassengerDenverRioGrande.java
@@ -73,7 +73,7 @@ public class EntityPassengerDenverRioGrande extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.ironBogie.item, 4), new ItemStack(ItemIDs.woodenFrame.item, 3), 
                 null, null, new ItemStack(ItemIDs.woodenCab.item, 3), 

--- a/src/main/java/train/entity/rollingStock/EntityPassengerDenverRioGrandeCombo.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassengerDenverRioGrandeCombo.java
@@ -78,7 +78,7 @@ public class EntityPassengerDenverRioGrandeCombo extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.chest, 4), new ItemStack(ItemIDs.ironBogie.item, 4), new ItemStack(ItemIDs.woodenFrame.item, 3), 
                 null, null, new ItemStack(ItemIDs.woodenCab.item, 3), 

--- a/src/main/java/train/entity/rollingStock/EntityPassengerGS4.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassengerGS4.java
@@ -91,7 +91,7 @@ public class EntityPassengerGS4 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 1), 
                 null, null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityPassengerGS4_Observatory.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassengerGS4_Observatory.java
@@ -88,7 +88,7 @@ public class EntityPassengerGS4_Observatory extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.glass, 1), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 1), 
                 null, null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityPassengerGS4_Tail.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassengerGS4_Tail.java
@@ -87,7 +87,7 @@ public class EntityPassengerGS4_Tail extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 1), 
                 null, null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityPassengerHighSpeedCarZeroED.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassengerHighSpeedCarZeroED.java
@@ -67,7 +67,7 @@ public class EntityPassengerHighSpeedCarZeroED extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityPassengerICE_1class.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassengerICE_1class.java
@@ -67,7 +67,7 @@ public class EntityPassengerICE_1class extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 null, null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityPassengerICE_2class.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassengerICE_2class.java
@@ -67,7 +67,7 @@ public class EntityPassengerICE_2class extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 null, null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityPassengerICE_Restaurant.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassengerICE_Restaurant.java
@@ -67,7 +67,7 @@ public class EntityPassengerICE_Restaurant extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 null, null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityPassengerMILW.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassengerMILW.java
@@ -67,7 +67,7 @@ public class EntityPassengerMILW extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 1), 
                 null, null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityPassengerMILWTail.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassengerMILWTail.java
@@ -67,7 +67,7 @@ public class EntityPassengerMILWTail extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 1), 
                 null, null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityPassengerRheingold.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassengerRheingold.java
@@ -77,7 +77,7 @@ public class EntityPassengerRheingold extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 1), 
                 null, null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityPassengerRheingoldDining1.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassengerRheingoldDining1.java
@@ -78,7 +78,7 @@ public class EntityPassengerRheingoldDining1 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 1), 
                 null, null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityPassengerRheingoldDining2.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassengerRheingoldDining2.java
@@ -78,7 +78,7 @@ public class EntityPassengerRheingoldDining2 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 1), 
                 null, null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityPassengerRheingoldPanorama.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassengerRheingoldPanorama.java
@@ -70,7 +70,7 @@ public class EntityPassengerRheingoldPanorama extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.glass, 1), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 1), 
                 null, null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityPassengerTramNY.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassengerTramNY.java
@@ -67,7 +67,7 @@ public class EntityPassengerTramNY extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 1), 
                 new ItemStack(ItemIDs.steel.item, 1), null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityPassenger_1class_DB.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassenger_1class_DB.java
@@ -68,7 +68,7 @@ public class EntityPassenger_1class_DB extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityPassenger_2class_DB.java
+++ b/src/main/java/train/entity/rollingStock/EntityPassenger_2class_DB.java
@@ -68,7 +68,7 @@ public class EntityPassenger_2class_DB extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/EntityPropagandaBritain.java
+++ b/src/main/java/train/entity/rollingStock/EntityPropagandaBritain.java
@@ -75,7 +75,7 @@ public class EntityPropagandaBritain extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 2), new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 2), 
                 null, null, null, null, null, new ItemStack(Items.painting, 2)        };

--- a/src/main/java/train/entity/rollingStock/EntityPropagandaJapan.java
+++ b/src/main/java/train/entity/rollingStock/EntityPropagandaJapan.java
@@ -76,7 +76,7 @@ public class EntityPropagandaJapan extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 2), new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 2), 
                 null, null, null, null, null, new ItemStack(Items.painting, 2)        };

--- a/src/main/java/train/entity/rollingStock/EntityPropagandaUS.java
+++ b/src/main/java/train/entity/rollingStock/EntityPropagandaUS.java
@@ -75,7 +75,7 @@ public class EntityPropagandaUS extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 2), new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 2), 
                 null, null, null, null, null, new ItemStack(Items.painting, 2)        };

--- a/src/main/java/train/entity/rollingStock/EntityPropagandaUSSR.java
+++ b/src/main/java/train/entity/rollingStock/EntityPropagandaUSSR.java
@@ -76,7 +76,7 @@ public class EntityPropagandaUSSR extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 2), new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 2), 
                 null, null, null, null, null, new ItemStack(Items.painting, 2)        };

--- a/src/main/java/train/entity/rollingStock/EntityStockCar.java
+++ b/src/main/java/train/entity/rollingStock/EntityStockCar.java
@@ -75,7 +75,7 @@ public class EntityStockCar extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 6), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Items.leather, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityStockCarDRWG.java
+++ b/src/main/java/train/entity/rollingStock/EntityStockCarDRWG.java
@@ -69,7 +69,7 @@ public class EntityStockCarDRWG extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 6), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Items.leather, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityTankLava.java
+++ b/src/main/java/train/entity/rollingStock/EntityTankLava.java
@@ -71,7 +71,7 @@ public class EntityTankLava extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Items.iron_ingot, 6), new ItemStack(ItemIDs.woodenBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 2), 
                 new ItemStack(Items.stick, 2), null, null, null, null, new ItemStack(Items.lava_bucket, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityTankWagon.java
+++ b/src/main/java/train/entity/rollingStock/EntityTankWagon.java
@@ -68,7 +68,7 @@ public class EntityTankWagon extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 6), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Items.water_bucket, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityTankWagon2.java
+++ b/src/main/java/train/entity/rollingStock/EntityTankWagon2.java
@@ -68,7 +68,7 @@ public class EntityTankWagon2 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 6), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Items.water_bucket, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityTankWagonThreeDome.java
+++ b/src/main/java/train/entity/rollingStock/EntityTankWagonThreeDome.java
@@ -70,7 +70,7 @@ public class EntityTankWagonThreeDome extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 4), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 3), 
                 new ItemStack(ItemIDs.steel.item, 4), null, null, null, null, new ItemStack(Items.water_bucket, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityTankWagonUS.java
+++ b/src/main/java/train/entity/rollingStock/EntityTankWagonUS.java
@@ -72,7 +72,7 @@ public class EntityTankWagonUS extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 6), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Items.water_bucket, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityTankWagon_DB.java
+++ b/src/main/java/train/entity/rollingStock/EntityTankWagon_DB.java
@@ -70,7 +70,7 @@ public class EntityTankWagon_DB extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 5), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Items.water_bucket, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityTender4000.java
+++ b/src/main/java/train/entity/rollingStock/EntityTender4000.java
@@ -74,7 +74,7 @@ public class EntityTender4000 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 6), new ItemStack(ItemIDs.bogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 3), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Items.coal, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityTender4_4_0.java
+++ b/src/main/java/train/entity/rollingStock/EntityTender4_4_0.java
@@ -80,7 +80,7 @@ public class EntityTender4_4_0 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 1), 
                 new ItemStack(Items.stick, 2), null, null, null, null, new ItemStack(Items.coal, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityTenderA4.java
+++ b/src/main/java/train/entity/rollingStock/EntityTenderA4.java
@@ -76,7 +76,7 @@ public class EntityTenderA4 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(Items.iron_ingot, 1), null, null, null, null, new ItemStack(Items.coal, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityTenderAdler.java
+++ b/src/main/java/train/entity/rollingStock/EntityTenderAdler.java
@@ -68,7 +68,7 @@ public class EntityTenderAdler extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Items.iron_ingot, 2), new ItemStack(ItemIDs.woodenBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 1), 
                 new ItemStack(Items.iron_ingot, 1), null, null, null, null, new ItemStack(Items.coal, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityTenderBR01_DB.java
+++ b/src/main/java/train/entity/rollingStock/EntityTenderBR01_DB.java
@@ -69,7 +69,7 @@ public class EntityTenderBR01_DB extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 4), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Items.coal, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityTenderBerk1225.java
+++ b/src/main/java/train/entity/rollingStock/EntityTenderBerk1225.java
@@ -70,7 +70,7 @@ public class EntityTenderBerk1225 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 4), new ItemStack(ItemIDs.steelframe.item, 4), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Items.coal, 2)        };

--- a/src/main/java/train/entity/rollingStock/EntityTenderC62Class.java
+++ b/src/main/java/train/entity/rollingStock/EntityTenderC62Class.java
@@ -70,7 +70,7 @@ public class EntityTenderC62Class extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 6), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Items.coal, 2)        };

--- a/src/main/java/train/entity/rollingStock/EntityTenderCoranationClass.java
+++ b/src/main/java/train/entity/rollingStock/EntityTenderCoranationClass.java
@@ -68,7 +68,7 @@ public class EntityTenderCoranationClass extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 6), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 3), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Items.coal, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityTenderD51.java
+++ b/src/main/java/train/entity/rollingStock/EntityTenderD51.java
@@ -68,7 +68,7 @@ public class EntityTenderD51 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 1), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Items.coal, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityTenderEr_Ussr.java
+++ b/src/main/java/train/entity/rollingStock/EntityTenderEr_Ussr.java
@@ -68,7 +68,7 @@ public class EntityTenderEr_Ussr extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 6), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 3), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Items.coal, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityTenderFowler4F.java
+++ b/src/main/java/train/entity/rollingStock/EntityTenderFowler4F.java
@@ -68,7 +68,7 @@ public class EntityTenderFowler4F extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 3), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Items.coal, 2)        };

--- a/src/main/java/train/entity/rollingStock/EntityTenderGS4.java
+++ b/src/main/java/train/entity/rollingStock/EntityTenderGS4.java
@@ -70,7 +70,7 @@ public class EntityTenderGS4 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Items.coal, 2), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 1), 
                 null, null, null, null, null, null        };

--- a/src/main/java/train/entity/rollingStock/EntityTenderHeavy.java
+++ b/src/main/java/train/entity/rollingStock/EntityTenderHeavy.java
@@ -68,7 +68,7 @@ public class EntityTenderHeavy extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 4), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 4), 
                 new ItemStack(ItemIDs.steel.item, 2), null, null, null, null, new ItemStack(Items.coal, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityTenderMILW.java
+++ b/src/main/java/train/entity/rollingStock/EntityTenderMILW.java
@@ -68,7 +68,7 @@ public class EntityTenderMILW extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Items.coal, 2), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 1), 
                 null, null, null, null, null, null        };

--- a/src/main/java/train/entity/rollingStock/EntityTenderSmall.java
+++ b/src/main/java/train/entity/rollingStock/EntityTenderSmall.java
@@ -76,7 +76,7 @@ public class EntityTenderSmall extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.woodenBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 1), 
                 new ItemStack(Items.stick, 2), null, null, null, null, new ItemStack(Items.coal, 1)        };

--- a/src/main/java/train/entity/rollingStock/EntityTender_C41.java
+++ b/src/main/java/train/entity/rollingStock/EntityTender_C41.java
@@ -68,7 +68,7 @@ public class EntityTender_C41 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Items.iron_ingot, 2), new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.ironFrame.item, 2), 
                 new ItemStack(Items.iron_ingot, 2), null, null, null, null, new ItemStack(Items.coal, 2)        };

--- a/src/main/java/train/entity/rollingStock/EntityTender_Southern1102.java
+++ b/src/main/java/train/entity/rollingStock/EntityTender_Southern1102.java
@@ -68,7 +68,7 @@ public class EntityTender_Southern1102 extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Items.iron_ingot, 2), new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.ironFrame.item, 2), 
                 new ItemStack(Items.iron_ingot, 2), null, null, null, null, new ItemStack(Items.coal, 2)        };

--- a/src/main/java/train/entity/rollingStock/EntityTracksBuilder.java
+++ b/src/main/java/train/entity/rollingStock/EntityTracksBuilder.java
@@ -68,7 +68,7 @@ public class EntityTracksBuilder extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 6), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 3), 
                 new ItemStack(ItemIDs.steel.item, 1), new ItemStack(ItemIDs.steelchimney.item, 1), null, new ItemStack(ItemIDs.boiler.item, 1), new ItemStack(ItemIDs.firebox.item, 1), new ItemStack(Blocks.rail, 16)        };

--- a/src/main/java/train/entity/rollingStock/EntityWorkCart.java
+++ b/src/main/java/train/entity/rollingStock/EntityWorkCart.java
@@ -69,7 +69,7 @@ public class EntityWorkCart extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.crafting_table, 1), new ItemStack(ItemIDs.woodenBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 1), 
                 new ItemStack(Items.stick, 2), null, new ItemStack(ItemIDs.woodenCab.item, 1), 

--- a/src/main/java/train/entity/rollingStock/PassengerIC4_DSB_FG.java
+++ b/src/main/java/train/entity/rollingStock/PassengerIC4_DSB_FG.java
@@ -66,7 +66,7 @@ public class PassengerIC4_DSB_FG extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return null;
     }
 

--- a/src/main/java/train/entity/rollingStock/PassengerIC4_DSB_FH.java
+++ b/src/main/java/train/entity/rollingStock/PassengerIC4_DSB_FH.java
@@ -66,7 +66,7 @@ public class PassengerIC4_DSB_FH extends GenericRailTransport {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return null;
     }
 

--- a/src/main/java/train/entity/trains/EntityLocoDiesel44TonSwitcher.java
+++ b/src/main/java/train/entity/trains/EntityLocoDiesel44TonSwitcher.java
@@ -69,7 +69,7 @@ public class EntityLocoDiesel44TonSwitcher extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 1), new ItemStack(ItemIDs.bogie.item, 4), new ItemStack(ItemIDs.steelframe.item, 3), 
                 null, null, new ItemStack(ItemIDs.steelcab.item, 2), 

--- a/src/main/java/train/entity/trains/EntityLocoDieselBamboo.java
+++ b/src/main/java/train/entity/trains/EntityLocoDieselBamboo.java
@@ -99,7 +99,7 @@ public class EntityLocoDieselBamboo extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.woodenBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 1),
                 null, null, null, null, new ItemStack(ItemIDs.dieselengine.item, 1), null        };

--- a/src/main/java/train/entity/trains/EntityLocoDieselCD742.java
+++ b/src/main/java/train/entity/trains/EntityLocoDieselCD742.java
@@ -77,7 +77,7 @@ public class EntityLocoDieselCD742 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 2), new ItemStack(ItemIDs.bogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoDieselChME3.java
+++ b/src/main/java/train/entity/trains/EntityLocoDieselChME3.java
@@ -69,7 +69,7 @@ public class EntityLocoDieselChME3 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 1), new ItemStack(ItemIDs.bogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoDieselClass66.java
+++ b/src/main/java/train/entity/trains/EntityLocoDieselClass66.java
@@ -73,7 +73,7 @@ public class EntityLocoDieselClass66 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 2), new ItemStack(ItemIDs.bogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoDieselDD35A.java
+++ b/src/main/java/train/entity/trains/EntityLocoDieselDD35A.java
@@ -71,7 +71,7 @@ public class EntityLocoDieselDD35A extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 2), new ItemStack(ItemIDs.bogie.item, 8), new ItemStack(ItemIDs.steelframe.item, 3), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 2), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoDieselDeltic.java
+++ b/src/main/java/train/entity/trains/EntityLocoDieselDeltic.java
@@ -69,7 +69,7 @@ public class EntityLocoDieselDeltic extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 2), new ItemStack(ItemIDs.bogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoDieselEMDF3.java
+++ b/src/main/java/train/entity/trains/EntityLocoDieselEMDF3.java
@@ -81,7 +81,7 @@ public class EntityLocoDieselEMDF3 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 2), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 null, null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoDieselEMDF7.java
+++ b/src/main/java/train/entity/trains/EntityLocoDieselEMDF7.java
@@ -81,7 +81,7 @@ public class EntityLocoDieselEMDF7 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 2), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 null, null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoDieselFOLM1.java
+++ b/src/main/java/train/entity/trains/EntityLocoDieselFOLM1.java
@@ -73,7 +73,7 @@ public class EntityLocoDieselFOLM1 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 2), new ItemStack(ItemIDs.bogie.item, 8), new ItemStack(ItemIDs.steelframe.item, 3), 
                 new ItemStack(ItemIDs.steel.item, 2), null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoDieselGP7Red.java
+++ b/src/main/java/train/entity/trains/EntityLocoDieselGP7Red.java
@@ -99,7 +99,7 @@ public class EntityLocoDieselGP7Red extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 2), new ItemStack(ItemIDs.bogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoDieselIC4_DSB_MG.java
+++ b/src/main/java/train/entity/trains/EntityLocoDieselIC4_DSB_MG.java
@@ -70,7 +70,7 @@ public class EntityLocoDieselIC4_DSB_MG extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return null;
     }
 

--- a/src/main/java/train/entity/trains/EntityLocoDieselKof_DB.java
+++ b/src/main/java/train/entity/trains/EntityLocoDieselKof_DB.java
@@ -77,7 +77,7 @@ public class EntityLocoDieselKof_DB extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 1), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 1), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoDieselMILW_H1044.java
+++ b/src/main/java/train/entity/trains/EntityLocoDieselMILW_H1044.java
@@ -83,7 +83,7 @@ public class EntityLocoDieselMILW_H1044 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 2), new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 2), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoDieselSD40.java
+++ b/src/main/java/train/entity/trains/EntityLocoDieselSD40.java
@@ -81,7 +81,7 @@ public class EntityLocoDieselSD40 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 2), new ItemStack(ItemIDs.bogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoDieselSD70.java
+++ b/src/main/java/train/entity/trains/EntityLocoDieselSD70.java
@@ -81,7 +81,7 @@ public class EntityLocoDieselSD70 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 2), new ItemStack(ItemIDs.bogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoDieselShunter.java
+++ b/src/main/java/train/entity/trains/EntityLocoDieselShunter.java
@@ -75,7 +75,7 @@ public class EntityLocoDieselShunter extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 1), new ItemStack(ItemIDs.bogie.item, 4), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoDieselV60_DB.java
+++ b/src/main/java/train/entity/trains/EntityLocoDieselV60_DB.java
@@ -75,7 +75,7 @@ public class EntityLocoDieselV60_DB extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 1), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoDieselWLs40.java
+++ b/src/main/java/train/entity/trains/EntityLocoDieselWLs40.java
@@ -69,7 +69,7 @@ public class EntityLocoDieselWLs40 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 1), new ItemStack(ItemIDs.bogie.item, 4), new ItemStack(ItemIDs.steelframe.item, 2), 
                 null, null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoElectricBP4.java
+++ b/src/main/java/train/entity/trains/EntityLocoElectricBP4.java
@@ -71,7 +71,7 @@ public class EntityLocoElectricBP4 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 2), new ItemStack(ItemIDs.bogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoElectricBR185.java
+++ b/src/main/java/train/entity/trains/EntityLocoElectricBR185.java
@@ -93,7 +93,7 @@ public class EntityLocoElectricBR185 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 2), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 null, null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoElectricBR_E69.java
+++ b/src/main/java/train/entity/trains/EntityLocoElectricBR_E69.java
@@ -79,7 +79,7 @@ public class EntityLocoElectricBR_E69 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 2), new ItemStack(ItemIDs.bogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 1), new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoElectricCD151.java
+++ b/src/main/java/train/entity/trains/EntityLocoElectricCD151.java
@@ -73,7 +73,7 @@ public class EntityLocoElectricCD151 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 2), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 1), 
                 new ItemStack(ItemIDs.steel.item, 2), null, new ItemStack(ItemIDs.steelcab.item, 2), 

--- a/src/main/java/train/entity/trains/EntityLocoElectricClass85.java
+++ b/src/main/java/train/entity/trains/EntityLocoElectricClass85.java
@@ -69,7 +69,7 @@ public class EntityLocoElectricClass85 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 2), new ItemStack(ItemIDs.bogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 1), new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoElectricE103.java
+++ b/src/main/java/train/entity/trains/EntityLocoElectricE103.java
@@ -71,7 +71,7 @@ public class EntityLocoElectricE103 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 2), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 2), new ItemStack(ItemIDs.steelcab.item, 2), 

--- a/src/main/java/train/entity/trains/EntityLocoElectricE10_DB.java
+++ b/src/main/java/train/entity/trains/EntityLocoElectricE10_DB.java
@@ -77,7 +77,7 @@ public class EntityLocoElectricE10_DB extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 2), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 2), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoElectricHighSpeedZeroED.java
+++ b/src/main/java/train/entity/trains/EntityLocoElectricHighSpeedZeroED.java
@@ -69,7 +69,7 @@ public class EntityLocoElectricHighSpeedZeroED extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 2), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 1),
                 new ItemStack(ItemIDs.steel.item, 1), null, new ItemStack(ItemIDs.steelcab.item, 1),

--- a/src/main/java/train/entity/trains/EntityLocoElectricICE1.java
+++ b/src/main/java/train/entity/trains/EntityLocoElectricICE1.java
@@ -69,7 +69,7 @@ public class EntityLocoElectricICE1 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 2), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 2), 
                 null, null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoElectricMinetrain.java
+++ b/src/main/java/train/entity/trains/EntityLocoElectricMinetrain.java
@@ -69,7 +69,7 @@ public class EntityLocoElectricMinetrain extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Items.iron_ingot, 2), new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.ironFrame.item, 1), 
                 new ItemStack(Items.iron_ingot, 1), null, new ItemStack(ItemIDs.controls.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoElectricTramNY.java
+++ b/src/main/java/train/entity/trains/EntityLocoElectricTramNY.java
@@ -72,7 +72,7 @@ public class EntityLocoElectricTramNY extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 1), new ItemStack(ItemIDs.bogie.item, 2), new ItemStack(ItemIDs.steelframe.item, 1), 
                 new ItemStack(ItemIDs.steel.item, 1), null, new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoElectricTramWood.java
+++ b/src/main/java/train/entity/trains/EntityLocoElectricTramWood.java
@@ -72,7 +72,7 @@ public class EntityLocoElectricTramWood extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 4), new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 1),
                 new ItemStack(Items.iron_ingot, 1), null, new ItemStack(ItemIDs.woodenCab.item, 1),

--- a/src/main/java/train/entity/trains/EntityLocoElectricVL10.java
+++ b/src/main/java/train/entity/trains/EntityLocoElectricVL10.java
@@ -69,7 +69,7 @@ public class EntityLocoElectricVL10 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.controls.item, 2), new ItemStack(ItemIDs.bogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 1), new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteam040VB.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteam040VB.java
@@ -70,7 +70,7 @@ public class EntityLocoSteam040VB extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 4), new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 1), 
                 null, new ItemStack(ItemIDs.ironChimney.item, 1), null, new ItemStack(ItemIDs.boiler.item, 1), new ItemStack(ItemIDs.firebox.item, 1), null        };

--- a/src/main/java/train/entity/trains/EntityLocoSteam262T.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteam262T.java
@@ -69,7 +69,7 @@ public class EntityLocoSteam262T extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.ironBogie.item, 4), new ItemStack(ItemIDs.woodenFrame.item, 1), 
                 null, new ItemStack(ItemIDs.ironChimney.item, 1), new ItemStack(ItemIDs.ironCab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteam4_4_0.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteam4_4_0.java
@@ -178,7 +178,7 @@ public class EntityLocoSteam4_4_0 extends EntityTrainCore {
      * @see ebf.tim.utility.RecipeManager#ODC(ItemStack)
      */
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.ironChimney.item, 1), new ItemStack(Items.stick, 2), null,
                 new ItemStack(ItemIDs.ironBoiler.item, 1), new ItemStack(ItemIDs.ironFirebox.item, 1), new ItemStack(ItemIDs.woodenCab.item, 1),

--- a/src/main/java/train/entity/trains/EntityLocoSteamAdler.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamAdler.java
@@ -70,7 +70,7 @@ public class EntityLocoSteamAdler extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 8), new ItemStack(ItemIDs.woodenBogie.item, 3), new ItemStack(ItemIDs.woodenFrame.item, 2), 
                 new ItemStack(Items.iron_ingot, 2), new ItemStack(ItemIDs.ironChimney.item, 1), null, new ItemStack(ItemIDs.ironBoiler.item, 1), new ItemStack(ItemIDs.ironFirebox.item, 1), new ItemStack(Items.gold_ingot, 2)        };

--- a/src/main/java/train/entity/trains/EntityLocoSteamAlcoSC4.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamAlcoSC4.java
@@ -69,7 +69,7 @@ public class EntityLocoSteamAlcoSC4 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.ironFrame.item, 2), 
                 new ItemStack(Items.iron_ingot, 2), new ItemStack(ItemIDs.ironChimney.item, 1), new ItemStack(ItemIDs.ironCab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamAlice0_4_0.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamAlice0_4_0.java
@@ -70,7 +70,7 @@ public class EntityLocoSteamAlice0_4_0 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 2), new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 1), 
                 null, new ItemStack(ItemIDs.ironChimney.item, 1), null, new ItemStack(ItemIDs.boiler.item, 1), new ItemStack(ItemIDs.firebox.item, 1), null        };

--- a/src/main/java/train/entity/trains/EntityLocoSteamBR01_DB.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamBR01_DB.java
@@ -69,7 +69,7 @@ public class EntityLocoSteamBR01_DB extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamBR80_DB.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamBR80_DB.java
@@ -71,7 +71,7 @@ public class EntityLocoSteamBR80_DB extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.ironBogie.item, 3), new ItemStack(ItemIDs.ironFrame.item, 2), 
                 new ItemStack(Items.iron_ingot, 2), new ItemStack(ItemIDs.ironChimney.item, 1), new ItemStack(ItemIDs.ironCab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamBerk1225.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamBerk1225.java
@@ -69,7 +69,7 @@ public class EntityLocoSteamBerk1225 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 4), new ItemStack(ItemIDs.steelframe.item, 4), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 2), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamBerk765.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamBerk765.java
@@ -69,7 +69,7 @@ public class EntityLocoSteamBerk765 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 4), new ItemStack(ItemIDs.steelframe.item, 4), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 2), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamC41.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamC41.java
@@ -69,7 +69,7 @@ public class EntityLocoSteamC41 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.ironBogie.item, 3), new ItemStack(ItemIDs.ironFrame.item, 2), 
                 new ItemStack(Items.iron_ingot, 2), new ItemStack(ItemIDs.ironChimney.item, 1), new ItemStack(ItemIDs.ironCab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamC41T.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamC41T.java
@@ -69,7 +69,7 @@ public class EntityLocoSteamC41T extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.ironBogie.item, 3), new ItemStack(ItemIDs.ironFrame.item, 2), 
                 new ItemStack(Items.iron_ingot, 2), new ItemStack(ItemIDs.ironChimney.item, 1), new ItemStack(ItemIDs.ironCab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamC41_080.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamC41_080.java
@@ -69,7 +69,7 @@ public class EntityLocoSteamC41_080 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.ironBogie.item, 6), new ItemStack(ItemIDs.ironFrame.item, 2), 
                 new ItemStack(Items.iron_ingot, 2), new ItemStack(ItemIDs.ironChimney.item, 1), new ItemStack(ItemIDs.ironCab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamC62Class.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamC62Class.java
@@ -71,7 +71,7 @@ public class EntityLocoSteamC62Class extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.bogie.item, 5), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamCherepanov.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamCherepanov.java
@@ -69,7 +69,7 @@ public class EntityLocoSteamCherepanov extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.woodenBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 1), 
                 new ItemStack(Items.stick, 1), new ItemStack(ItemIDs.ironChimney.item, 1), null, new ItemStack(ItemIDs.ironBoiler.item, 1), new ItemStack(ItemIDs.ironFirebox.item, 1), null        };

--- a/src/main/java/train/entity/trains/EntityLocoSteamClimax.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamClimax.java
@@ -69,7 +69,7 @@ public class EntityLocoSteamClimax extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.ironBogie.item, 3), new ItemStack(ItemIDs.ironFrame.item, 1),
                 null, new ItemStack(ItemIDs.ironChimney.item, 1), new ItemStack(ItemIDs.woodenCab.item, 1),

--- a/src/main/java/train/entity/trains/EntityLocoSteamCoranationClass.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamCoranationClass.java
@@ -69,7 +69,7 @@ public class EntityLocoSteamCoranationClass extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 3), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 2), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamD51.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamD51.java
@@ -71,7 +71,7 @@ public class EntityLocoSteamD51 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.bogie.item, 5), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamD51Long.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamD51Long.java
@@ -71,7 +71,7 @@ public class EntityLocoSteamD51Long extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.bogie.item, 5), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamEr_Ussr.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamEr_Ussr.java
@@ -70,7 +70,7 @@ public class EntityLocoSteamEr_Ussr extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 3), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 2), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamForneyRed.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamForneyRed.java
@@ -79,7 +79,7 @@ public class EntityLocoSteamForneyRed extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.ironBogie.item, 3), new ItemStack(ItemIDs.ironFrame.item, 2), 
                 new ItemStack(Items.iron_ingot, 2), new ItemStack(ItemIDs.ironChimney.item, 1), new ItemStack(ItemIDs.ironCab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamFowler.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamFowler.java
@@ -69,7 +69,7 @@ public class EntityLocoSteamFowler extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 4), new ItemStack(ItemIDs.steelframe.item, 4), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 2), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamGLYN042T.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamGLYN042T.java
@@ -69,7 +69,7 @@ public class EntityLocoSteamGLYN042T extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.ironBogie.item, 3), new ItemStack(ItemIDs.ironFrame.item, 1), 
                 null, new ItemStack(ItemIDs.ironChimney.item, 1), new ItemStack(ItemIDs.woodenCab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamGS4.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamGS4.java
@@ -71,7 +71,7 @@ public class EntityLocoSteamGS4 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 4), new ItemStack(ItemIDs.steelframe.item, 1), 
                 null, new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamHallClass.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamHallClass.java
@@ -73,7 +73,7 @@ public class EntityLocoSteamHallClass extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 3), 
                 new ItemStack(ItemIDs.steel.item, 1), new ItemStack(ItemIDs.steelchimney.item, 2), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamHeavy.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamHeavy.java
@@ -69,7 +69,7 @@ public class EntityLocoSteamHeavy extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 3), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamKingClass.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamKingClass.java
@@ -73,7 +73,7 @@ public class EntityLocoSteamKingClass extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 3), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 2), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamLSSP7.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamLSSP7.java
@@ -69,7 +69,7 @@ public class EntityLocoSteamLSSP7 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.woodenBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 2), 
                 null, null, new ItemStack(ItemIDs.ironCab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamMILWClassA.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamMILWClassA.java
@@ -69,7 +69,7 @@ public class EntityLocoSteamMILWClassA extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 4), new ItemStack(ItemIDs.steelframe.item, 1), 
                 null, new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamMallardA4.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamMallardA4.java
@@ -87,7 +87,7 @@ public class EntityLocoSteamMallardA4 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(Items.iron_ingot, 2), null,
                 new ItemStack(ItemIDs.ironBoiler.item, 2), new ItemStack(ItemIDs.ironFirebox.item, 1), new ItemStack(ItemIDs.steelcab.item, 1),

--- a/src/main/java/train/entity/trains/EntityLocoSteamMogulBlue.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamMogulBlue.java
@@ -79,7 +79,7 @@ public class EntityLocoSteamMogulBlue extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamPannier.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamPannier.java
@@ -69,7 +69,7 @@ public class EntityLocoSteamPannier extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.bogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 3), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamShay.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamShay.java
@@ -69,7 +69,7 @@ public class EntityLocoSteamShay extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.ironBogie.item, 3), new ItemStack(ItemIDs.ironFrame.item, 2), 
                 new ItemStack(Items.iron_ingot, 2), new ItemStack(ItemIDs.ironChimney.item, 1), new ItemStack(ItemIDs.ironCab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamSmall.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamSmall.java
@@ -78,7 +78,7 @@ public class EntityLocoSteamSmall extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.woodenBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 2), 
                 new ItemStack(Items.stick, 2), new ItemStack(ItemIDs.ironChimney.item, 1), new ItemStack(ItemIDs.woodenCab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamSnowPlow.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamSnowPlow.java
@@ -71,7 +71,7 @@ public class EntityLocoSteamSnowPlow extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 4), 
                 null, new ItemStack(ItemIDs.ironChimney.item, 1), new ItemStack(ItemIDs.woodenCab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamSouthern1102.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamSouthern1102.java
@@ -69,7 +69,7 @@ public class EntityLocoSteamSouthern1102 extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.ironBogie.item, 3), new ItemStack(ItemIDs.ironFrame.item, 2), 
                 new ItemStack(Items.iron_ingot, 2), new ItemStack(ItemIDs.ironChimney.item, 1), new ItemStack(ItemIDs.ironCab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamUSATCUK.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamUSATCUK.java
@@ -69,7 +69,7 @@ public class EntityLocoSteamUSATCUK extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.ironBogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamUSATCUS.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamUSATCUS.java
@@ -69,7 +69,7 @@ public class EntityLocoSteamUSATCUS extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 null, new ItemStack(ItemIDs.ironBogie.item, 3), new ItemStack(ItemIDs.steelframe.item, 2), 
                 new ItemStack(ItemIDs.steel.item, 2), new ItemStack(ItemIDs.steelchimney.item, 1), new ItemStack(ItemIDs.steelcab.item, 1), 

--- a/src/main/java/train/entity/trains/EntityLocoSteamVBShay.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamVBShay.java
@@ -70,7 +70,7 @@ public class EntityLocoSteamVBShay extends EntityTrainCore {
 
     //recipe
     @Override
-    public ItemStack[] getRecipie() {
+    public ItemStack[] getRecipe() {
         return new ItemStack[]{
                 new ItemStack(Blocks.planks, 2), new ItemStack(ItemIDs.ironBogie.item, 2), new ItemStack(ItemIDs.woodenFrame.item, 2), 
                 null, new ItemStack(ItemIDs.ironChimney.item, 1), new ItemStack(ItemIDs.woodenCab.item, 1), 


### PR DESCRIPTION
- fixed the spelling of "Recipe" that was in GenericRailTransport which
affected all extensions of that class.
- fixed bug with train crafting not showing correct trains for a recipe,
or none at all when null was an ingredient in recipe.

There are a lot more crafting-related bugs I'd like to fix, but I don't have any more time today and I wanted to get this pr in because it has some massive fixes compared to what is coming.
Large unfixed crafting-related bugs that I know about:
* readNBT does not get called for the train table when loading the world.
* Scrolling on a train in the train crafting gui crashes game
* Steel things are turning into iron things when recipehandler registers it. Ex. steelChimney turns into ironChimney…
* No arrows for going through the list of things (but the spaces for the buttons are there).
