### PR TITLE
Crafting bug fixes and TiM and TC simultaneous crafting

### DIFF
--- a/src/main/java/ebf/tim/blocks/TileEntityStorage.java
+++ b/src/main/java/ebf/tim/blocks/TileEntityStorage.java
@@ -66,7 +66,7 @@ public class TileEntityStorage extends TileRenderFacing implements IInventory, I
                 //tile entity's crafting grid (right hand grid)
                 for (int l = 0; l < 3; ++l) {
                     for (int i1 = 0; i1 < 3; ++i1) {
-                        inventory.add(new ItemStackSlot(this, s).setCoords(106 + i1 * 18, 17 + l * 18).setCraftingOutput(true));
+                        inventory.add(new ItemStackSlot(this, s, assemblyTableTier).setCoords(106 + i1 * 18, 17 + l * 18).setCraftingOutput(true));
                         s++;
                     }
                 }
@@ -88,14 +88,16 @@ public class TileEntityStorage extends TileRenderFacing implements IInventory, I
                 //create the assembly table output slots (9-16)
                 for(int i = 0; i < 2; ++i){
                     for(int j = 0; j < 4; ++j){
-                        inventory.add(new ItemStackSlot(this, (s+9) + (j + i * 4)).setCoords(92 + j * 18, (128) + i * 18).setCraftingOutput(true));
+                        inventory.add(new ItemStackSlot(this, (s+9) + (j + i * 4), assemblyTableTier).setCoords(92 + j * 18, (128) + i * 18).setCraftingOutput(true));
                     }
                 }
 
                 //create the assembly table storage slots
+                //  slots 35 - 400 were meant for storage
+                int storageSlot = 36;
                 for(int i = 0; i < 2; ++i) {
                     for (int j = 0; j < 4; ++j) {
-                        inventory.add(new ItemStackSlot(this, (s + 17) + (j + i * 4)).setCoords(8 + j * 18, (128) + i * 18));
+                        inventory.add(new ItemStackSlot(this, (storageSlot) + (j + i * 4)).setCoords(8 + j * 18, (128) + i * 18));
                     }
                 }
             }

--- a/src/main/java/ebf/tim/blocks/TileEntityStorage.java
+++ b/src/main/java/ebf/tim/blocks/TileEntityStorage.java
@@ -41,17 +41,21 @@ public class TileEntityStorage extends TileRenderFacing implements IInventory, I
         super(block);
         int s=400;
 
-        if (block.assemblyTableTier != -1) {
-            //if it's a traintable, it should be, things might break otherwise, this is temporary to see if I missed a case.
-            this.assemblyTableTier = block.assemblyTableTier;
-        } else {
-            DebugUtil.println("Did not set the tier of the assembly table/traintable!");
-            this.assemblyTableTier = 1;
-        }
-
         inventory= new ArrayList<>();
-        if(block.getUnlocalizedName().equals("tile.block.traintabletier1") || block.getUnlocalizedName().equals("tile.block.traintabletier2") || block.getUnlocalizedName().equals("tile.block.traintabletier3")){
-            if (!ClientProxy.isTraincraft) {
+        if(block.getUnlocalizedName().equals("tile.block.traintabletier1") ||
+                block.getUnlocalizedName().equals("tile.block.traintabletier2") ||
+                block.getUnlocalizedName().equals("tile.block.traintabletier3") ||
+                block.getUnlocalizedName().equals("tile.block.traintable")) {
+
+            if (block.assemblyTableTier != -1) {
+                //if it's a traintable, it should be, things might break otherwise, this is temporary to see if I missed a case.
+                this.assemblyTableTier = block.assemblyTableTier;
+            } else {
+                DebugUtil.println("Did not set the tier of the assembly table/traintable!");
+                this.assemblyTableTier = 0;
+            }
+
+            if (!ClientProxy.isTraincraft || block.getUnlocalizedName().equals("tile.block.traintable")) {
                 //inventory grid (left grid)
                 for (int l = 0; l < 3; ++l) {
                     for (int i1 = 0; i1 < 3; ++i1) {

--- a/src/main/java/ebf/tim/entities/GenericRailTransport.java
+++ b/src/main/java/ebf/tim/entities/GenericRailTransport.java
@@ -2214,12 +2214,14 @@ public class GenericRailTransport extends EntityMinecart implements IEntityAddit
         };
     }
 
-    /**Returns the train's crafting tier. This decides which assembly table is needed to craft it (I, II, or III)
+    /**Both decides whether to use Traincraft's assemblytables or TiM's traintable for the crafting of this transport.
+     * Return 0 (or don't override this at all - default is 0) to use TiM's traintable.
+     * Return 1, 2 or 3 to use the corresponding tier of assemblytable.
      *
-     * @return either 1, 2, or 3 corresponding to which table should be able to craft it.
+     * @return either 1, 2, or 3 corresponding to which table should be able to craft it, or 0, to use the TiM traintable instead.
      */
     public int getTier() {
-        return 1;
+        return 0;
     }
 
     /**defines the name used for registration and the default name used in the gui.*/

--- a/src/main/java/ebf/tim/gui/GUITrainTable.java
+++ b/src/main/java/ebf/tim/gui/GUITrainTable.java
@@ -32,7 +32,7 @@ public class GUITrainTable extends GuiContainer {
 
     private String hostname;
 
-    //TODO: button placement broken, functionality broken, possibly re-evaluate how to do this (need access to TileEntityStorage)
+    //TODO: button placement broken, functionality broken
     private GuiButton upButton = new GuiButton(0, 146, 127, 21, 21, "UP");
     private GuiButton downButton = new GuiButton(0, 146, 147, 21, 21, "DN");
 
@@ -40,7 +40,7 @@ public class GUITrainTable extends GuiContainer {
         super(new TransportSlotManager(inventoryPlayer, (TileEntityStorage) world.getTileEntity(x,y,z)));
         hostname=world.getBlock(x,y,z).getUnlocalizedName();
 
-        if (ClientProxy.isTraincraft) {
+        if (ClientProxy.isTraincraft && !hostname.equals("tile.block.traintable")) {
             this.ySize = 256;
         }
     }
@@ -58,10 +58,10 @@ public class GUITrainTable extends GuiContainer {
     }
 
     protected void drawGuiContainerForegroundLayer(int p_146979_1_, int p_146979_2_) {
-        if (!ClientProxy.isTraincraft) {
+        if (!ClientProxy.isTraincraft || hostname.equals("tile.block.traintable")) {
             this.fontRendererObj.drawString(I18n.format("container.inventory"), 8, this.ySize - 96 + 2, 4210752);
         } else {
-            if (hostname.equals("tile.block.traintabletier1") || hostname.equals("tile.block.traintabletier2") || hostname.equals("tile.block.traintabletier3")) {
+            if (hostname.startsWith("tile.block.traintable")) {
                 //assembly table and traincraft
                 //TODO: localize strings, edit colors if need be.
                 this.fontRendererObj.drawString(I18n.format("container.inventory"), 8, this.ySize - 92, 4210752);
@@ -120,8 +120,8 @@ public class GUITrainTable extends GuiContainer {
             GL11.glEnable(GL11.GL_LIGHTING);
             GL11.glPopMatrix();
 
-        } else if (hostname.equals("tile.block.traintabletier1") || hostname.equals("tile.block.traintabletier2") || hostname.equals("tile.block.traintabletier3")){
-            if (!ClientProxy.isTraincraft) { //TiM stuff
+        } else if (hostname.startsWith("tile.block.traintable")){
+            if (!ClientProxy.isTraincraft || hostname.equals("tile.block.traintable")) { //TiM stuff
                 this.mc.getTextureManager().bindTexture(ClientUtil.craftingTableGuiTextures);
                 this.drawTexturedModalRect(guiLeft, guiTop, 0, 0, this.xSize, this.ySize);
 

--- a/src/main/java/ebf/tim/registry/TiMBlocks.java
+++ b/src/main/java/ebf/tim/registry/TiMBlocks.java
@@ -16,7 +16,7 @@ import static ebf.tim.registry.TiMGenericRegistry.registerBlock;
 public class TiMBlocks {
 
     /**the crafting table for trains*/
-    public static BlockDynamic trainTable = new BlockDynamic(new Material(MapColor.mapColorArray[13]), true, true); //original
+    public static BlockDynamic trainTable = new BlockDynamic(new Material(MapColor.mapColorArray[13]), true, true, 0); //tier 0 = "no tier"
 
     public static BlockDynamic railTable = new BlockDynamic(new Material(MapColor.mapColorArray[6]), true, true);
 

--- a/src/main/java/ebf/tim/registry/TiMGenericRegistry.java
+++ b/src/main/java/ebf/tim/registry/TiMGenericRegistry.java
@@ -252,10 +252,10 @@ public class TiMGenericRegistry {
             GameRegistry.registerItem(registry.getCartItem().getItem(), registry.getCartItem().getItem().getUnlocalizedName());
             if(registry.getRecipe()!=null) {
                 if (CommonProxy.recipesInMods.containsKey(MODID)) {
-                    CommonProxy.recipesInMods.get(MODID).add(getRecipe(registry.getRecipe(), registry.getCartItem()));
+                    CommonProxy.recipesInMods.get(MODID).add(getRecipe(registry.getRecipe(), registry.getCartItem(), registry.getTier()));
                 } else {
                     CommonProxy.recipesInMods.put(MODID, new ArrayList<Recipe>());
-                    CommonProxy.recipesInMods.get(MODID).add(getRecipe(registry.getRecipe(), registry.getCartItem()));
+                    CommonProxy.recipesInMods.get(MODID).add(getRecipe(registry.getRecipe(), registry.getCartItem(), registry.getTier()));
                 }
             }
             if(TrainsInMotion.proxy.isClient() && ClientProxy.hdTransportItems){
@@ -263,7 +263,7 @@ public class TiMGenericRegistry {
             }
             registry.registerSkins();
             if(registry.getRecipe()!=null){
-                RecipeManager.registerRecipe(registry.getRecipe(), registry.getCartItem());
+                RecipeManager.registerRecipe(registry.getRecipe(), registry.getCartItem(), registry.getTier());
             }
             ItemCraftGuide.itemEntries.add(registry.getClass());
             if(TrainsInMotion.proxy.isClient()) {

--- a/src/main/java/ebf/tim/utility/Recipe.java
+++ b/src/main/java/ebf/tim/utility/Recipe.java
@@ -49,7 +49,7 @@ public class Recipe {
         input.add(Arrays.asList(bottomCenter));
         input.add(Arrays.asList(bottomRight));
 
-        tier = 1;
+        tier = 0;
     }
 
     @Deprecated
@@ -72,7 +72,7 @@ public class Recipe {
         input.add(Collections.singletonList(bottomCenter));
         input.add(Collections.singletonList(bottomRight));
 
-        tier = 1;
+        tier = 0;
     }
 
     //gets the individual stacks to check for crafting matches

--- a/src/main/java/ebf/tim/utility/RecipeManager.java
+++ b/src/main/java/ebf/tim/utility/RecipeManager.java
@@ -64,6 +64,7 @@ public class RecipeManager {
     }
 
     /**Compares and returns a list of trains that are craftable with the given array of ItemStacks (the inputted recipe)
+     * Funnily enough, in wanting to have a tier-less traintable, I implemented a fourth tier, tier 0.
      *
      * @param recipe An array of ItemStacks that could be a valid recipe.
      * @param tier The tier to compare recipes against. Will only look for results in given tier.

--- a/src/main/java/ebf/tim/utility/RecipeManager.java
+++ b/src/main/java/ebf/tim/utility/RecipeManager.java
@@ -21,8 +21,8 @@ public class RecipeManager {
     //private static List<Item> ingotDirectory = new ArrayList<>();
 
 
-    public static void registerRecipe(Object[] recipe, ItemStack output){
-        registerRecipe(getRecipe(recipe,output));
+    public static void registerRecipe(Object[] recipe, ItemStack output, int tier){
+        registerRecipe(getRecipe(recipe, output, tier));
     }
 
     public static void registerRecipe(Recipe recipe){
@@ -183,8 +183,8 @@ public class RecipeManager {
 
 
 
-    public static Recipe getRecipe(Object[] obj, ItemStack cartItem){
-        return new Recipe(new ItemStack[]{cartItem},
+    public static Recipe getRecipe(Object[] obj, ItemStack cartItem, int tier){
+        Recipe r = new Recipe(new ItemStack[]{cartItem},
                 getItem(obj[0]),
                 getItem(obj[1]),
                 getItem(obj[2]),
@@ -195,6 +195,8 @@ public class RecipeManager {
                 getItem(obj[7]),
                 getItem(obj[8])
         );
+        r.setTier(tier);
+        return r;
     }
 
     public static ItemStack[] getItem(Object itm){


### PR DESCRIPTION
Wanted to get this pr out yesterday, but some critical bugs popped up just as I was about to make the pr. The crafting system is nearing completion, with only a couple things left:
- NBT reading still broken on world load
- Drag clicking inside of output slots eats the items
- scrolling on an item when it's in the tileEntity's inventory crashes game (relates to NEI, see stacktrace when happens)
- buttons to scroll output needs implementation/packet system
  - creation code and some button functions are present in tileEntity and GUI, look for the TODOs around it.

Notable changes in this pr:
- Rewrote getMaxCraft
- Fixed bugs with slotClick
- Added support for simultaneous use of TiM and TC train crafting systems
- fixed massive oversight where tier of train would never actually get used and always be the fallback value.
- made default tier be 0, to use the TiM table unless told otherwise