### PR TITLE
Multiple crafting bug fixes, some remain.

### DIFF
--- a/src/main/java/ebf/tim/blocks/TileEntityStorage.java
+++ b/src/main/java/ebf/tim/blocks/TileEntityStorage.java
@@ -89,7 +89,7 @@ public class TileEntityStorage extends TileRenderFacing implements IInventory, I
                 //create the assembly table output slots (9-16)
                 for(int i = 0; i < 4; ++i){
                     for(int j = 0; j < 2; ++j){
-                        inventory.add(new ItemStackSlot(this, (s+9) + (j + i * 4), assemblyTableTier).setCoords(92 + i * 18, (128) + j * 18).setCraftingOutput(true));
+                        inventory.add(new ItemStackSlot(this, (s+9) + (j * 4 + i), assemblyTableTier).setCoords(92 + i * 18, (128) + j * 18).setCraftingOutput(true));
                     }
                 }
 

--- a/src/main/java/ebf/tim/gui/GUIButton.java
+++ b/src/main/java/ebf/tim/gui/GUIButton.java
@@ -61,7 +61,9 @@ public abstract class GUIButton extends GuiButton {
 
     @Override
     public void drawButton(Minecraft mc, int mouseX, int mouseY){
-        drawButton(mouseX, mouseY);
+        if (this.visible) {
+            drawButton(mouseX, mouseY);
+        }
     }
 
 

--- a/src/main/java/ebf/tim/gui/GUITrainTable.java
+++ b/src/main/java/ebf/tim/gui/GUITrainTable.java
@@ -4,15 +4,22 @@ import ebf.tim.TrainsInMotion;
 import ebf.tim.blocks.TileEntityStorage;
 import ebf.tim.networking.PacketCraftingPage;
 import ebf.tim.utility.*;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiLabel;
 import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,7 +58,15 @@ public class GUITrainTable extends GuiContainer {
 
         buttonList =new ArrayList();
 
-        this.buttonList.add(new GUIButton(guiLeft+105, guiTop+34, 18, 18,"<<"){
+        //adjust button position for TC vs TiM traintable
+        int[] upButtonCoord = {145, 126};
+        int[] downButtonCoord = {145, 144};
+        if (hostname.equals("tile.block.traintable")) {
+            upButtonCoord = new int[]{105, 34};
+            downButtonCoord = new int[]{141, 34};
+        }
+
+        this.buttonList.add(new GUIButton(guiLeft+upButtonCoord[0], guiTop+upButtonCoord[1], 18, 18,"<<"){
             @Override
             public String getHoverText() {
                 return "Previous Page";
@@ -62,7 +77,7 @@ public class GUITrainTable extends GuiContainer {
             }
         });
 
-        this.buttonList.add(new GUIButton(this.guiLeft + 141, this.guiTop + 34, 18,18, ">>") {
+        this.buttonList.add(new GUIButton(this.guiLeft + downButtonCoord[0], this.guiTop + downButtonCoord[1], 18,18, ">>") {
             @Override
             public String getHoverText() {
                 return "Next Page";

--- a/src/main/java/ebf/tim/utility/ItemStackSlot.java
+++ b/src/main/java/ebf/tim/utility/ItemStackSlot.java
@@ -237,7 +237,7 @@ public class ItemStackSlot extends Slot {
 
     /**
      * Helper function to fill the output slots with the given stacks. This is a method to account for the 9 output slots
-     * in TiM and the 7 in the Traincraft assemblytable. This could be merged back into original function (onCraftMatrixChanged).
+     * in TiM and the 8 in the Traincraft assemblytable. This could be merged back into original function (onCraftMatrixChanged).
      */
     private void putResultsInOutputSlots(IInventory hostInventory, List<ItemStackSlot> hostSlots, List<ItemStack> slots, int page, int numberSlots) {
         if(slots==null){
@@ -254,18 +254,22 @@ public class ItemStackSlot extends Slot {
                 ((TileEntityStorage)hostInventory).pages = 1;
                 ((TileEntityStorage)hostInventory).outputPage = 1;
             } else {//skip 2 since buttons will be in their place.
-                for (int i = 0; i < numberSlots-2; i++) {//TODO: disable the slots with buttons (last two)
-                    putStackInSlot(hostSlots,409 + i + ((numberSlots-2)*(page-1)), slots.get(i + ((numberSlots-2)*(page-1))));
+                if (tierIn > 0) {
+                    for (int i = 0; i < numberSlots - 2; i++) {//TODO: disable the slots with buttons (last two)
+                        putStackInSlot(hostSlots, 409 + i + ((numberSlots - 2) * (page - 1)), slots.get(i + ((numberSlots - 2) * (page - 1))));
+                    }
+                } else {
+                    //TiM crafter, but buttons in awkward place coding-wise
+                    putStackInSlot(hostSlots,409 + (7 * (page - 1)), slots.get(7 * (page - 1)));
+                    putStackInSlot(hostSlots,410 + (7 * (page - 1)), slots.get(1 + (7 * (page - 1))));
+                    putStackInSlot(hostSlots,411 + (7 * (page - 1)), slots.get(2 + (7 * (page - 1))));
+                    //intentionally skip 412 because an arrow is there
+                    putStackInSlot(hostSlots,413 + (7 * (page - 1)), slots.get(3 + (7 * (page - 1))));
+                    //intentionally skip 414 because an arrow is there
+                    putStackInSlot(hostSlots,415 + (7 * (page - 1)), slots.get(4 + (7 * (page - 1))));
+                    putStackInSlot(hostSlots,416 + (7 * (page - 1)), slots.get(5 + (7 * (page - 1))));
+                    putStackInSlot(hostSlots,417 + (7 * (page - 1)), slots.get(6 + (7 * (page - 1))));
                 }
-//                putStackInSlot(hostSlots,409 + (7*page), slots.get((7*page)));
-//                putStackInSlot(hostSlots,410 + (7*page), slots.get(1+ (7*page)));
-//                putStackInSlot(hostSlots,411 + (7*page), slots.get(2+ (7*page)));
-//                //intentionally skip 412 because an arrow is there
-//                putStackInSlot(hostSlots,413 + (7*page), slots.get(3+ (7*page)));
-//                //intentionally skip 414 because an arrow is there
-//                putStackInSlot(hostSlots,415 + (7*page), slots.get(4+ (7*page)));
-//                putStackInSlot(hostSlots,416 + (7*page), slots.get(5+ (7*page)));
-//                putStackInSlot(hostSlots,417 + (7*page), slots.get(6+ (7*page)));
 
                 //divide the possible trains by the number of usable slots on each page and round it up
                 ((TileEntityStorage)hostInventory).pages = (slots.size()/(numberSlots-2)) + 1;
@@ -520,4 +524,25 @@ public class ItemStackSlot extends Slot {
 
 
     public int getSlotID(){return slotID;}
+
+    /** Here, we use it to control whether or not to do the highlighting of slot when mousing over it.
+     * I am 99% sure it is used for that based on usages of the function found via IntelliJ.
+     * Function it overrides always returns true.
+     *
+     * @return boolean for if it should draw highlight
+     */
+    @Override
+    public boolean func_111238_b() {
+        //if the java ap exam taught me anything, it's short-circuit evaluation.
+        if (inventory instanceof TileEntityStorage && ((TileEntityStorage) inventory).pages > 1) {
+            if (tierIn > 0 && (slotID == 415 || slotID == 416)) {
+                //traincraft assemblyTables
+                return false;
+            } else if (tierIn == 0 && (slotID == 412 || slotID == 414)) {
+                //TiM traintable
+                return false;
+            }
+        }
+        return true;
+    }
 }


### PR DESCRIPTION
- fixed click related bugs:
- Drag clicking has many problems. Will allow items to be placed inside. Will eat said item.
- Double clicking on an item in the inventory will not pick up others in the inventory. Works fine for player inv and hotbar however.
- Assembly Tables shows only 4 trains when multiple pages of trains.

Remaining problems:
- readNBT does not get called for the train table when loading the world (already known)
- Scrolling on a train in the train crafting gui crashes game
  - Has to do with nei
  - asodiguzxcoivyiucvh
  - comment about this from below
  `    /**
     * The way functions use this function seems to rely on the slotID being equal to the place in the inventory array.
     * This way is what most minecraft things want, but NEI does not like it and likes the function commented out more.
     *
     * Right now, THIS IS PROBABLY **NOT** THE FUNCTIONALITY WE WANT! I did this so that NEI will not crash the game if
     * someone accidentally scrolls on an item. after thinking about it some, this could be pretty close, and this
     * function will more than likely need a disgusting solution. Probably would work if inventory sorted by slotID
     */` Except it still crashes

- Crashes when try to change page, related to packet system
