### PR TITLE
got pages to work, moved order of slot reg in container class

### DIFF
--- a/src/main/java/ebf/tim/blocks/TileEntityStorage.java
+++ b/src/main/java/ebf/tim/blocks/TileEntityStorage.java
@@ -36,6 +36,7 @@ public class TileEntityStorage extends TileRenderFacing implements IInventory, I
     public int storageType=0;
     public int outputPage=1;
     public int pages=1;
+
     public int assemblyTableTier = -1; //only applies if part of assemblyTable/traintable, no need to set otherwise.
 
     public TileEntityStorage(BlockDynamic block){
@@ -462,20 +463,16 @@ public class TileEntityStorage extends TileRenderFacing implements IInventory, I
             //get the number of remaining pages
             //if there are some, increment the outputPage int
             outputPage++;
-            for(ItemStackSlot slot: inventory) {
-                slot.onSlotChanged();
-                slot.onCraftMatrixChanged(this, inventory, false);
-            }
+            getSlotIndexByID(400).updatePage(this, inventory);
+            this.markDirty();
         }
     }
 
     public void decrementPage() {
         if (pages > 1 && outputPage > 1) {
             outputPage--;
-            for(ItemStackSlot slot: inventory) {
-                slot.onSlotChanged();
-                slot.onCraftMatrixChanged(this, inventory, false);
-            }
+            getSlotIndexByID(400).updatePage(this, inventory);
+            this.markDirty();
         }
     }
 

--- a/src/main/java/ebf/tim/networking/PacketCraftingPage.java
+++ b/src/main/java/ebf/tim/networking/PacketCraftingPage.java
@@ -2,14 +2,10 @@ package ebf.tim.networking;
 
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import ebf.tim.blocks.TileEntityStorage;
-import ebf.tim.entities.GenericRailTransport;
 import ebf.tim.utility.DebugUtil;
 import io.netty.buffer.ByteBuf;
-import net.minecraft.client.Minecraft;
-import net.minecraft.entity.Entity;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraftforge.common.DimensionManager;
 
 /**
  * <h1>Mount packet</h1>

--- a/src/main/java/ebf/tim/utility/ItemStackSlot.java
+++ b/src/main/java/ebf/tim/utility/ItemStackSlot.java
@@ -235,9 +235,19 @@ public class ItemStackSlot extends Slot {
         return 0;
     }
 
+    //seems to set the correct
+    public void updatePage(TileEntityStorage hostInventory, List<ItemStackSlot> hostSlots) {
+        List<ItemStack> slots = RecipeManager.getResult(RecipeManager.getTransportRecipe(hostInventory), this.tierIn);
+        if (hostInventory.assemblyTableTier > 0) {
+            putResultsInOutputSlots(hostInventory, hostSlots, slots, hostInventory.outputPage, 8);
+        } else if (hostInventory.assemblyTableTier == 0) {
+            putResultsInOutputSlots(hostInventory, hostSlots, slots, hostInventory.outputPage, 9);
+        }
+    }
+
     /**
      * Helper function to fill the output slots with the given stacks. This is a method to account for the 9 output slots
-     * in TiM and the 8 in the Traincraft assemblytable. This could be merged back into original function (onCraftMatrixChanged).
+     * in TiM and the 8 in the Traincraft assemblytable.
      */
     private void putResultsInOutputSlots(IInventory hostInventory, List<ItemStackSlot> hostSlots, List<ItemStack> slots, int page, int numberSlots) {
         if(slots==null){
@@ -280,11 +290,13 @@ public class ItemStackSlot extends Slot {
                 }
                 ((TileEntityStorage)hostInventory).pages = (slots.size()/(numberSlots-2)) + 1;
             }
+
+            onSlotChanged();
         }
     }
 
-    public void onCraftMatrixChanged(IInventory hostInventory, List<ItemStackSlot> hostSlots, boolean resetPage) {
-        if((isCraftingInput || isCraftingOutput) && hostInventory instanceof TileEntityStorage) {
+    public void onCraftMatrixChanged(IInventory hostInventory, List<ItemStackSlot> hostSlots) {
+        if((isCraftingInput || isCraftingOutput) && hostInventory instanceof TileEntityStorage && hostSlots.size() != 18) {
             int page = ((TileEntityStorage)hostInventory).outputPage;
             switch (((TileEntityStorage)hostInventory).storageType) {
                 case 1: { //train crafting
@@ -296,9 +308,8 @@ public class ItemStackSlot extends Slot {
                         putResultsInOutputSlots(hostInventory, hostSlots, slots, page, 9);
                     }
 
-                    if (resetPage) {
-                        ((TileEntityStorage) hostInventory).outputPage = 1;
-                    }
+                    ((TileEntityStorage) hostInventory).outputPage = 1;
+
                     break;
                 }
                 case 0: { //track crafting
@@ -397,7 +408,7 @@ public class ItemStackSlot extends Slot {
             }
             this.onSlotChanged();
             if(hostInventory!=null) {
-                onCraftMatrixChanged(inventory, hostInventory, true);
+                onCraftMatrixChanged(inventory, hostInventory);
             }
             return true;
         }

--- a/src/main/java/ebf/tim/utility/TransportSlotManager.java
+++ b/src/main/java/ebf/tim/utility/TransportSlotManager.java
@@ -62,10 +62,6 @@ public class TransportSlotManager extends net.minecraft.inventory.Container {
         //tile entity reference
         hostInventory = block;
 
-        for(ItemStackSlot slot : block.inventory){
-            addSlots(slot);
-        }
-
         if (block.assemblyTableTier > 0 && ClientProxy.isTraincraft) { //it is an assembly table, move slots lower. (but only for the traincraft asm tables)
             //player hotbar
             for (int iT = 0; iT < 9; iT++) {
@@ -91,6 +87,11 @@ public class TransportSlotManager extends net.minecraft.inventory.Container {
                 }
             }
         }
+
+        for(ItemStackSlot slot : block.inventory){
+            addSlots(slot);
+        }
+
         onCraftMatrixChanged(hostInventory);
     }
 
@@ -164,6 +165,10 @@ public class TransportSlotManager extends net.minecraft.inventory.Container {
     /*a heavily modified replica of the 1.12 version*/
     @Override
     public ItemStack slotClick(int slotId, int dragType, int clickTypeIn, EntityPlayer player) {
+
+        if (hostInventory instanceof TileEntityStorage && ((TileEntityStorage) hostInventory).assemblyTableTier >= 0) {
+            this.detectAndSendChanges();
+        }
 
         if (clickTypeIn == 4){
             clickTypeIn = Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT) ? 1 ://cover shift click


### PR DESCRIPTION
I still don't fully understand why or how it works now, but it works, and I don't think I broke anything else. The change to the container class should not affect anything else and may also help with the NEI FastTransferManager bug because the list of slots is more in order of slotID. 
There seems to be a bug with the page resetting when taking a train, but this is not at all priority and will almost definitely not be a problem. I have spent wayyy too much time looking at these classes.