### PR TITLE
fully functionalized TC assemblytables with last slot

### DIFF
--- a/src/main/java/ebf/tim/blocks/TileEntityStorage.java
+++ b/src/main/java/ebf/tim/blocks/TileEntityStorage.java
@@ -10,7 +10,6 @@ import ebf.tim.utility.ItemStackSlot;
 import net.minecraft.block.Block;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.IInventory;
@@ -79,18 +78,19 @@ public class TileEntityStorage extends TileRenderFacing implements IInventory, I
                 inventory.add(new ItemStackSlot(this, s+1, assemblyTableTier).setCoords(79, 27).setCraftingInput(true));
                 inventory.add(new ItemStackSlot(this, s+2, assemblyTableTier).setCoords(115, 27).setCraftingInput(true));
                 //the following is dye slot, removed so we can have 9 crafting slots; if adding back, remember to increment everything
-                //inventory.add(new ItemStackSlot(this, s+3, assemblyTableTier).setCoords(145, 27).setCraftingInput(true));
-                inventory.add(new ItemStackSlot(this, s+3, assemblyTableTier).setCoords(25, 61).setCraftingInput(true));
-                inventory.add(new ItemStackSlot(this, s+4, assemblyTableTier).setCoords(79, 61).setCraftingInput(true));
-                inventory.add(new ItemStackSlot(this, s+5, assemblyTableTier).setCoords(115, 61).setCraftingInput(true));
-                inventory.add(new ItemStackSlot(this, s+6, assemblyTableTier).setCoords(43, 93).setCraftingInput(true));
-                inventory.add(new ItemStackSlot(this, s+7, assemblyTableTier).setCoords(79, 93).setCraftingInput(true));
-                inventory.add(new ItemStackSlot(this, s+8, assemblyTableTier).setCoords(145, 93).setCraftingInput(true));
+                inventory.add(new ItemStackSlot(this, s+3, assemblyTableTier).setCoords(145, 27).setCraftingInput(true));
+
+                inventory.add(new ItemStackSlot(this, s+4, assemblyTableTier).setCoords(25, 61).setCraftingInput(true));
+                inventory.add(new ItemStackSlot(this, s+5, assemblyTableTier).setCoords(79, 61).setCraftingInput(true));
+                inventory.add(new ItemStackSlot(this, s+6, assemblyTableTier).setCoords(115, 61).setCraftingInput(true));
+                inventory.add(new ItemStackSlot(this, s+7, assemblyTableTier).setCoords(43, 93).setCraftingInput(true));
+                inventory.add(new ItemStackSlot(this, s+8, assemblyTableTier).setCoords(79, 93).setCraftingInput(true));
+                inventory.add(new ItemStackSlot(this, s+9, assemblyTableTier).setCoords(145, 93).setCraftingInput(true));
 
                 //create the assembly table output slots (9-16)
                 for(int i = 0; i < 4; ++i){
                     for(int j = 0; j < 2; ++j){
-                        inventory.add(new ItemStackSlot(this, (s+9) + (j * 4 + i), assemblyTableTier).setCoords(92 + i * 18, (128) + j * 18).setCraftingOutput(true));
+                        inventory.add(new ItemStackSlot(this, (s+10) + (j * 4 + i), assemblyTableTier).setCoords(92 + i * 18, (128) + j * 18).setCraftingOutput(true));
                     }
                 }
 
@@ -110,7 +110,7 @@ public class TileEntityStorage extends TileRenderFacing implements IInventory, I
             inventory.add(new ItemStackSlot(this,402).setCoords( 30 , 37).setCraftingInput(true).setOverlay(Blocks.gravel)); //ballast
 
             inventory.add(new ItemStackSlot(this,403).setCoords( 50 , 7).setCraftingInput(true)); //wires
-            inventory.add(new ItemStackSlot(this,404).setCoords( 50 , 27).setCraftingInput(true));//augument slot
+            inventory.add(new ItemStackSlot(this,404).setCoords( 50 , 27).setCraftingInput(true));//augment slot
 
             inventory.add(new ItemStackSlot(this,405).setCoords( 124 , -2).setCraftingInput(true).setOverlay(Blocks.rail));//old shape input
 

--- a/src/main/java/ebf/tim/networking/PacketCraftingPage.java
+++ b/src/main/java/ebf/tim/networking/PacketCraftingPage.java
@@ -2,20 +2,18 @@ package ebf.tim.networking;
 
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import ebf.tim.blocks.TileEntityStorage;
-import ebf.tim.utility.DebugUtil;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.tileentity.TileEntity;
 
 /**
- * <h1>Mount packet</h1>
- * This is intended to be a replacement for
- * @see net.minecraft.network.play.client.C02PacketUseEntity
- * because for whatever reason, the stupid thing refuses to send for our entities.
+ * <h1>Change crafting output page packets</h1>
+ * The packet sends the left/right button press on the traintable gui to change
+ * the page of the output of the traintable, in case there are many possible crafts.
  * @author Eternal Blue Flame
  */
 public class PacketCraftingPage implements IMessage {
-    /**the ID of the entity to dismount from*/
+    /**true to go right, false for left*/
     private boolean key;
     private int x,y,z, dim;
 
@@ -36,7 +34,6 @@ public class PacketCraftingPage implements IMessage {
 
         TileEntity te =MinecraftServer.getServer().worldServers[dim].getTileEntity(x,y,z);
 
-        DebugUtil.println(dim,x,y,z);
         if(te instanceof TileEntityStorage){
             if(key) {
                 ((TileEntityStorage) te).incrementPage();

--- a/src/main/java/ebf/tim/utility/ItemStackSlot.java
+++ b/src/main/java/ebf/tim/utility/ItemStackSlot.java
@@ -250,16 +250,18 @@ public class ItemStackSlot extends Slot {
      * in TiM and the 8 in the Traincraft assemblytable.
      */
     private void putResultsInOutputSlots(IInventory hostInventory, List<ItemStackSlot> hostSlots, List<ItemStack> slots, int page, int numberSlots) {
+        int startSlot = 409;
+        if (tierIn > 0) startSlot = 410; //start one slot later for TC assemblytable
         if(slots==null){
             for (int i = 0; i < numberSlots; i++) {
-                putStackInSlot(hostSlots,409 + i, null);
+                putStackInSlot(hostSlots,startSlot + i, null);
             }
             ((TileEntityStorage) hostInventory).pages = 1;
             ((TileEntityStorage) hostInventory).outputPage = 1;
         } else {
             if(slots.size() <= numberSlots) {
                 for (int i = 0; i < numberSlots; i++) {
-                    putStackInSlot(hostSlots,409 + i, i >= slots.size() ?null: slots.get(i));
+                    putStackInSlot(hostSlots,startSlot + i, i >= slots.size() ?null: slots.get(i));
                 }
                 ((TileEntityStorage)hostInventory).pages = 1;
                 ((TileEntityStorage)hostInventory).outputPage = 1;
@@ -267,7 +269,7 @@ public class ItemStackSlot extends Slot {
                 if (tierIn > 0) { //TC
                     for (int i = 0; i < 6; i++) {
                         if (i + (6 * (page - 1)) < slots.size()) { //if slot is in bounds
-                            putStackInSlot(hostSlots, 409 + i, slots.get(i + ((numberSlots - 2) * (page - 1))));
+                            putStackInSlot(hostSlots, startSlot + i, slots.get(i + ((numberSlots - 2) * (page - 1))));
                         } else {
                             break;
                         }

--- a/src/main/java/ebf/tim/utility/Recipe.java
+++ b/src/main/java/ebf/tim/utility/Recipe.java
@@ -13,8 +13,8 @@ public class Recipe {
 
     List<ItemStack> result = new ArrayList<>();
     List<List<ItemStack>> input = new ArrayList<>();
-    private int tier = 0; //a tier either 1, 2, or 3
-    private int[] displayItem=new int[]{0,0,0,0,0,0,0,0,0,0};
+    private int tier = 0; //a tier either 0, 1, 2, or 3
+    private int[] displayItem=new int[]{0,0,0,0,0,0,0,0,0,0}; //idk what this for, but it will have to be changed for supporting 10 input slots
 
 
     public Recipe(List<ItemStack> results, List<List<ItemStack>> cost, int tier) {
@@ -127,6 +127,9 @@ public class Recipe {
 
 
     public boolean inputMatches(List<ItemStack> stacks){
+        //first make sure that stacks isn't too small, ie. recipe for 9 slots and stacks is 10
+        if (stacks.size() < input.size()) return false;
+
         int i=0;
         for(List<ItemStack> slot : input){
             for(ItemStack s : slot){

--- a/src/main/java/ebf/tim/utility/TransportSlotManager.java
+++ b/src/main/java/ebf/tim/utility/TransportSlotManager.java
@@ -92,7 +92,7 @@ public class TransportSlotManager extends net.minecraft.inventory.Container {
             addSlots(slot);
         }
 
-        onCraftMatrixChanged(hostInventory);
+        detectAndSendChanges();
     }
 
     /**

--- a/src/main/java/train/entity/trains/EntityLocoSteamUSATCUK.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamUSATCUK.java
@@ -68,11 +68,15 @@ public class EntityLocoSteamUSATCUK extends EntityTrainCore {
     }
 
 
-    //recipe
+    @Override
+    public int getTier() {
+        return 1;
+    }
+
     @Override
     public ItemStack[] getRecipe() {
         return new ItemStack[]{
-                null, new ItemStack(TiMItems.wheelIron, 3), new ItemStack(TiMItems.frameSteel, 2),
+                null, new ItemStack(TiMItems.wheelIron, 3), new ItemStack(TiMItems.frameSteel, 2), new ItemStack(Items.dye, 8),
                 new ItemStack(TiMOres.ingotSteel, 2), new ItemStack(TiMItems.chimneySteel, 1), new ItemStack(TiMItems.cabinSteel, 1),
                 new ItemStack(TiMItems.boilerIron, 1), new ItemStack(TiMItems.fireboxIron, 1), new ItemStack(Items.coal, 1)        };
     }

--- a/src/main/java/train/entity/trains/EntityLocoSteamUSATCUS.java
+++ b/src/main/java/train/entity/trains/EntityLocoSteamUSATCUS.java
@@ -68,11 +68,15 @@ public class EntityLocoSteamUSATCUS extends EntityTrainCore {
     }
 
 
-    //recipe
+    @Override
+    public int getTier() {
+        return 1;
+    }
+
     @Override
     public ItemStack[] getRecipe() {
         return new ItemStack[]{
-                null, new ItemStack(TiMItems.wheelIron, 3), new ItemStack(TiMItems.frameSteel, 2),
+                null, new ItemStack(TiMItems.wheelIron, 3), new ItemStack(TiMItems.frameSteel, 2), new ItemStack(Items.dye, 8),
                 new ItemStack(TiMOres.ingotSteel, 2), new ItemStack(TiMItems.chimneySteel, 1), new ItemStack(TiMItems.cabinSteel, 1),
                 new ItemStack(TiMItems.boilerIron, 1), new ItemStack(TiMItems.fireboxIron, 1), new ItemStack(Items.coal, 1)        };
     }

--- a/src/main/resources/assets/trainsinmotion/lang/en_US.lang
+++ b/src/main/resources/assets/trainsinmotion/lang/en_US.lang
@@ -215,6 +215,8 @@ item.stephenson.valve.gear.name=Stephenson Valve Gear
 item.baker.valve.gear.name=Baker Valve Gear
 item.radial.valve.gear.name=Radial Valve Gear
 item.conjugating.valve.gear.name=Conjugating Valve Gear
+item.firebox.iron.name=Iron Firebox
+item.firebox.steel.name=Steel Firebox
 
 <!-- ## Blocks ## -->
 fluid.oil=Oil


### PR DESCRIPTION
- added dye slot capability to TC assemblytable,
- assemblytables should now work with all 10 slots available for
crafting
- fixed some documentation
- added a couple lang things
- converted two trains to use the TC assembly tables utilizing all 10 slots and tiers (USATCUS, USATCUK trains)
- system should now by able to handle any size recipe and custom tiers,
if add-on creators want to create more tables, it is easy using tiers.
(contact me for more info if you want to do bc may be bugs, did not test creating new
addon table)

- found some bad bugs
  - DO NOT shiftclick items into the tables when the crafting  slots are
  full, it will eat your item.
  - bad dupe bug found, will not write here to prevent exploitation