### PR TITLE
Fixed double if statement

### DIFF
--- a/src/main/java/train/common/tile/TileEntityDistil.java
+++ b/src/main/java/train/common/tile/TileEntityDistil.java
@@ -196,14 +196,10 @@ public class TileEntityDistil extends TileTraincraft implements IFluidHandler {
 
 			if (theTank.getFluid() != null) {
 				amount = theTank.getFluid().amount;
-			}
-			else {
-				amount = 0;
-			}
-			if (theTank.getFluid() != null) {
 				liquidItemID = theTank.getFluid().getFluidID();
 			}
 			else {
+				amount = 0;
 				liquidItemID = 0;
 			}
 			if (updateTicks % 8 == 0){


### PR DESCRIPTION
# Summary
Theres a useless `if` statement in the distil tile entity. This PR fixes it.

# Changes
Changed the double `if` statement to a single if