### PR TITLE
fixed json not parsing when used as jar

### DIFF
--- a/src/main/java/ebf/tim/TrainsInMotion.java
+++ b/src/main/java/ebf/tim/TrainsInMotion.java
@@ -142,7 +142,7 @@ public class TrainsInMotion {
         proxy.register();
 
         //parse and register json crafting recipes
-        JsonRecipeHelper.loadRecipes("/assets/trainsinmotion/recipes/");
+        JsonRecipeHelper.loadRecipes(MODID);
 
         //loop for registering the entities. the values needed are the class, entity name, entity ID, mod instance, update range, update rate, and if it does velocity things,
         cpw.mods.fml.common.registry.EntityRegistry.registerModEntity(EntityBogie.class, "Bogie", 15, TrainsInMotion.instance, 60, 3, true);

--- a/src/main/java/train/Traincraft.java
+++ b/src/main/java/train/Traincraft.java
@@ -160,7 +160,7 @@ public class Traincraft {
 		TCItems.init();
 
 		//parse and register json crafting recipes
-		JsonRecipeHelper.loadRecipes("/assets/traincraft/recipes/");
+		JsonRecipeHelper.loadRecipes(Info.modID);
 
 		if(ConfigHandler.ENABLE_STEAM) {
 			//the null last value defines we aren't implementing a custom entity render.


### PR DESCRIPTION
"Small" commit but very necessary as json recipes are not usable without it.

Commit message:
in jar vs ide the files work differently, so I needed a new way of
finding the recipe files in the jar. The new method is a lot more
complicated and a bit slower, but it must be this way. I will
work on making this more efficient, but it only runs on startup.