### PR TITLE
Fuel Compat with BC RC Forestry IE TiM

### DIFF
--- a/src/main/java/ebf/tim/registry/TiMFluids.java
+++ b/src/main/java/ebf/tim/registry/TiMFluids.java
@@ -8,6 +8,7 @@ import net.minecraft.block.material.MapColor;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
 
 import java.util.Collection;
 
@@ -36,6 +37,11 @@ public class TiMFluids {
     public static Fluid fluidRedstone = new Fluid("Redstone");
     public static Item bucketRedstone;
 
+    public static Fluid fluidBCFuel = FluidRegistry.getFluid("fuel");
+    public static Fluid fluidEthanol = FluidRegistry.getFluid("bioethanol");
+    public static Fluid fluidBiofuel = FluidRegistry.getFluid("biofuel");
+    public static Fluid fluidBioDiesel = FluidRegistry.getFluid("biodiesel");
+    public static Fluid fluidBiomass = FluidRegistry.getFluid("biomass");
 
     public static Fluid nullFluid = new Fluid("nullFluid");
 
@@ -76,6 +82,8 @@ public class TiMFluids {
             TiMGenericRegistry.registerRCFluid(TiMFluids.fluidOil,5000);
             TiMGenericRegistry.registerRCFluid(TiMFluids.fluidDiesel, 10000);
         }
+        if (Loader.isModLoaded("Forestry")){
 
+        }
     }
 }

--- a/src/main/java/ebf/tim/registry/TiMFluids.java
+++ b/src/main/java/ebf/tim/registry/TiMFluids.java
@@ -1,11 +1,15 @@
 package ebf.tim.registry;
 
+import buildcraft.api.fuels.BuildcraftFuelRegistry;
+import cpw.mods.fml.common.Loader;
 import ebf.tim.TrainsInMotion;
 import ebf.tim.blocks.OreGen;
 import net.minecraft.block.material.MapColor;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraftforge.fluids.Fluid;
+
+import java.util.Collection;
 
 import static ebf.tim.registry.TiMGenericRegistry.RegisterFluid;
 import static ebf.tim.registry.TiMGenericRegistry.registerOreGen;
@@ -32,7 +36,10 @@ public class TiMFluids {
     public static Fluid fluidRedstone = new Fluid("Redstone");
     public static Item bucketRedstone;
 
+
     public static Fluid nullFluid = new Fluid("nullFluid");
+
+
 
 
 
@@ -55,6 +62,20 @@ public class TiMFluids {
         //oil spawn underground
         registerOreGen(0,
                 new OreGen(fluidOil.getBlock(),40,60,20,6,3));
+
+
+
+        if (Loader.isModLoaded("BuildCraft|Energy")) {
+            TiMGenericRegistry.registerBCFluid(TiMFluids.fluidOil, 2500, 5000);
+            TiMGenericRegistry.registerBCFluid(TiMFluids.fluidDiesel, 5000, 10000);
+            TiMGenericRegistry.registerBCFluid(TiMFluids.fluidfueloil, 5000,25000);
+
+        }
+        if (Loader.isModLoaded("Railcraft")){
+            TiMGenericRegistry.registerRCFluid(TiMFluids.fluidfueloil,2500);
+            TiMGenericRegistry.registerRCFluid(TiMFluids.fluidOil,5000);
+            TiMGenericRegistry.registerRCFluid(TiMFluids.fluidDiesel, 10000);
+        }
 
     }
 }

--- a/src/main/java/ebf/tim/registry/TiMGenericRegistry.java
+++ b/src/main/java/ebf/tim/registry/TiMGenericRegistry.java
@@ -18,6 +18,7 @@ import ebf.tim.items.ItemCraftGuide;
 import ebf.tim.items.ItemTransport;
 import ebf.tim.utility.*;
 import fexcraft.tmt.slim.ModelBase;
+import li.cil.oc.integration.forestry.ModForestry;
 import mods.railcraft.api.fuel.FuelManager;
 import net.minecraft.block.Block;
 import net.minecraft.block.ITileEntityProvider;
@@ -66,49 +67,48 @@ public class TiMGenericRegistry {
     public Item[] recipe;
 
     //todo:purge redundancy checks on postinit
-    private static List<String>usedNames = new ArrayList<>();
-    private static List<String>redundantTiles = new ArrayList<>();
-    private static List<String>redundantBlocks = new ArrayList<>();
-    public static int registryPosition =18;
+    private static List<String> usedNames = new ArrayList<>();
+    private static List<String> redundantTiles = new ArrayList<>();
+    private static List<String> redundantBlocks = new ArrayList<>();
+    public static int registryPosition = 18;
 
-    public TiMGenericRegistry(GenericRailTransport transport, Item[] recipe){
+    public TiMGenericRegistry(GenericRailTransport transport, Item[] recipe) {
         this.transport = transport;
         this.recipe = recipe;
     }
 
     /**
-     *
-     * @param block the block in question
-     * @param tab the creative tab to put the block's item into, leave null for no creative tab entry.
-     * @param MODID modid of the host add-on, used for translations, texture names, and generic identification.
-     * @param unlocalizedName unlocalized name, used for translations, texture names, and generic identification.
+     * @param block             the block in question
+     * @param tab               the creative tab to put the block's item into, leave null for no creative tab entry.
+     * @param MODID             modid of the host add-on, used for translations, texture names, and generic identification.
+     * @param unlocalizedName   unlocalized name, used for translations, texture names, and generic identification.
      * @param oreDictionaryName ore directory name, used for other mods to identify type, mainly used for ingots, ores, and wood.
-     * @param render a ModelBase instance for rendering the tile entity.
-     *               Can instead be a TESR instance for more rendering control.
-     *               Null will fallback to a normal textured block render.
+     * @param render            a ModelBase instance for rendering the tile entity.
+     *                          Can instead be a TESR instance for more rendering control.
+     *                          Null will fallback to a normal textured block render.
      * @return
      */
-    public static Block registerBlock(Block block, CreativeTabs tab, String MODID, String unlocalizedName, @Nullable String oreDictionaryName, @Nullable Object render){
-        if(render instanceof ModelBase){
+    public static Block registerBlock(Block block, CreativeTabs tab, String MODID, String unlocalizedName, @Nullable String oreDictionaryName, @Nullable Object render) {
+        if (render instanceof ModelBase) {
             return registerBlock(block, tab, MODID, unlocalizedName, oreDictionaryName, TrainsInMotion.proxy.getTESR(), (ModelBase) render);
         } else {
             return registerBlock(block, tab, MODID, unlocalizedName, oreDictionaryName, render, null);
         }
     }
 
-    public static Block registerBlock(Block block, CreativeTabs tab, String unlocalizedName, @Nullable String oreDictionaryName, @Nullable Object render){
+    public static Block registerBlock(Block block, CreativeTabs tab, String unlocalizedName, @Nullable String oreDictionaryName, @Nullable Object render) {
         return registerBlock(block, tab, null, unlocalizedName, oreDictionaryName, render);
     }
 
-    public static Block registerBlock(Block block, CreativeTabs tab, String MODID, String unlocalizedName, @Nullable String oreDictionaryName, @Nullable Object TESR, @Nullable ModelBase model){
-        if(usedNames.contains(unlocalizedName)){
+    public static Block registerBlock(Block block, CreativeTabs tab, String MODID, String unlocalizedName, @Nullable String oreDictionaryName, @Nullable Object TESR, @Nullable ModelBase model) {
+        if (usedNames.contains(unlocalizedName)) {
             DebugUtil.println("ERROR: ", "attempted to register Block with a used unlocalizedName", unlocalizedName);
             DebugUtil.throwStackTrace();
         }
-        if (tab!=null){
+        if (tab != null) {
             block.setCreativeTab(tab);
         }
-        if (unlocalizedName.length()>0){
+        if (unlocalizedName.length() > 0) {
             block.setBlockName(unlocalizedName);
             GameRegistry.registerBlock(block, unlocalizedName);
             usedNames.add(unlocalizedName);
@@ -117,35 +117,35 @@ public class TiMGenericRegistry {
             DebugUtil.throwStackTrace();
         }
 
-        if(TrainsInMotion.proxy.isClient() && MODID!=null){
-            block.setBlockTextureName(MODID+":"+unlocalizedName);
+        if (TrainsInMotion.proxy.isClient() && MODID != null) {
+            block.setBlockTextureName(MODID + ":" + unlocalizedName);
         }
-        if(oreDictionaryName!=null){
+        if (oreDictionaryName != null) {
             OreDictionary.registerOre(oreDictionaryName, block);
         }
-        if (DebugUtil.dev() && TrainsInMotion.proxy.isClient() && block.getUnlocalizedName().equals(StatCollector.translateToLocal(block.getUnlocalizedName()))){
+        if (DebugUtil.dev() && TrainsInMotion.proxy.isClient() && block.getUnlocalizedName().equals(StatCollector.translateToLocal(block.getUnlocalizedName()))) {
             DebugUtil.println("Block missing lang entry: " + block.getUnlocalizedName());
         }
-        if(block instanceof BlockDynamic) {
-            if(model!=null) {
+        if (block instanceof BlockDynamic) {
+            if (model != null) {
                 ((BlockDynamic) block).setModel(model);
-            } else if (TESR!=null){
+            } else if (TESR != null) {
                 ((BlockDynamic) block).setTESR(TESR);
             }
         }
-        if(block instanceof ITileEntityProvider){
-            Class<? extends TileEntity> tile=((ITileEntityProvider)block).createNewTileEntity(null,0).getClass();
-            if(!redundantTiles.contains(unlocalizedName + "tile")) {
+        if (block instanceof ITileEntityProvider) {
+            Class<? extends TileEntity> tile = ((ITileEntityProvider) block).createNewTileEntity(null, 0).getClass();
+            if (!redundantTiles.contains(unlocalizedName + "tile")) {
                 GameRegistry.registerTileEntity(tile, unlocalizedName + "tile");
                 redundantTiles.add(unlocalizedName + "tile");
                 if (TrainsInMotion.proxy.isClient() && TESR != null) {
                     cpw.mods.fml.client.registry.ClientRegistry.bindTileEntitySpecialRenderer(tile, (TileEntitySpecialRenderer) TESR);
                     MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(block), CustomItemModel.instance);
-                    CustomItemModel.registerBlockTextures(Item.getItemFromBlock(block), ((ITileEntityProvider)block).createNewTileEntity(null,0));
-                } else if (TrainsInMotion.proxy.isClient()){
+                    CustomItemModel.registerBlockTextures(Item.getItemFromBlock(block), ((ITileEntityProvider) block).createNewTileEntity(null, 0));
+                } else if (TrainsInMotion.proxy.isClient()) {
                     cpw.mods.fml.client.registry.ClientRegistry.bindTileEntitySpecialRenderer(tile, (TileEntitySpecialRenderer) TrainsInMotion.proxy.getTESR());
                     MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(block), CustomItemModel.instance);
-                    CustomItemModel.registerBlockTextures(Item.getItemFromBlock(block), ((ITileEntityProvider)block).createNewTileEntity(null,0));
+                    CustomItemModel.registerBlockTextures(Item.getItemFromBlock(block), ((ITileEntityProvider) block).createNewTileEntity(null, 0));
                 }
             } else {
                 DebugUtil.println("redundant tile name found", unlocalizedName + "tile");
@@ -155,43 +155,43 @@ public class TiMGenericRegistry {
         return block;
     }
 
-    public static Item RegisterItem(Item itm, String MODID, String unlocalizedName, CreativeTabs tab){
-        return RegisterItem(itm, MODID, unlocalizedName,null,tab, null,null);
+    public static Item RegisterItem(Item itm, String MODID, String unlocalizedName, CreativeTabs tab) {
+        return RegisterItem(itm, MODID, unlocalizedName, null, tab, null, null);
     }
 
-    public static Item RegisterItem(Item itm, String MODID, String unlocalizedName, @Nullable String oreDictionaryName, @Nullable CreativeTabs tab, @Nullable Item container, @Nullable Object itemRender){
-        if(usedNames.contains(unlocalizedName)){
+    public static Item RegisterItem(Item itm, String MODID, String unlocalizedName, @Nullable String oreDictionaryName, @Nullable CreativeTabs tab, @Nullable Item container, @Nullable Object itemRender) {
+        if (usedNames.contains(unlocalizedName)) {
             DebugUtil.println("ERROR: ", "attempted to register Item with a used unlocalizedName", unlocalizedName);
             DebugUtil.throwStackTrace();
         }
-        if (tab!=null) {
+        if (tab != null) {
             itm.setCreativeTab(tab);
         }
-        if (container!=null){
+        if (container != null) {
             itm.setContainerItem(container);
         }
-        if (!unlocalizedName.equals("")){
+        if (!unlocalizedName.equals("")) {
             itm.setUnlocalizedName(unlocalizedName);
             usedNames.add(unlocalizedName);
         } else {
             DebugUtil.println("ERROR: ", "attempted to register Item with no unlocalizedName");
             DebugUtil.throwStackTrace();
         }
-        if(TrainsInMotion.proxy.isClient()){
-            itm.setTextureName(MODID+":"+unlocalizedName);
+        if (TrainsInMotion.proxy.isClient()) {
+            itm.setTextureName(MODID + ":" + unlocalizedName);
         }
-        GameRegistry.registerItem(itm,unlocalizedName);
-        if(oreDictionaryName!=null){
+        GameRegistry.registerItem(itm, unlocalizedName);
+        if (oreDictionaryName != null) {
             OreDictionary.registerOre(oreDictionaryName, itm);
         }
-        if (DebugUtil.dev() && TrainsInMotion.proxy!=null && TrainsInMotion.proxy.isClient() && itm.getUnlocalizedName().equals(StatCollector.translateToLocal(itm.getUnlocalizedName()))){
+        if (DebugUtil.dev() && TrainsInMotion.proxy != null && TrainsInMotion.proxy.isClient() && itm.getUnlocalizedName().equals(StatCollector.translateToLocal(itm.getUnlocalizedName()))) {
             DebugUtil.println("Item missing lang entry: " + itm.getUnlocalizedName());
         }
-        if(TrainsInMotion.proxy.isClient() && itemRender!=null){
-            MinecraftForgeClient.registerItemRenderer(itm, (IItemRenderer)itemRender);
-        } else if (TrainsInMotion.proxy.isClient() && itm instanceof ItemTransport){
+        if (TrainsInMotion.proxy.isClient() && itemRender != null) {
+            MinecraftForgeClient.registerItemRenderer(itm, (IItemRenderer) itemRender);
+        } else if (TrainsInMotion.proxy.isClient() && itm instanceof ItemTransport) {
             MinecraftForgeClient.registerItemRenderer(itm, ebf.tim.items.CustomItemModel.instance);
-            if(ClientProxy.preRenderModels) {
+            if (ClientProxy.preRenderModels) {
                 ebf.tim.items.CustomItemModel.instance.renderItem(IItemRenderer.ItemRenderType.INVENTORY, new ItemStack(itm));
             }
         }
@@ -199,12 +199,12 @@ public class TiMGenericRegistry {
     }
 
 
-    public static void RegisterFluid(Fluid fluid, @Nullable Item bucket, String MODID, String unlocalizedName, boolean isGaseous, int density, MapColor color, @Nullable CreativeTabs tab){
-        if(usedNames.contains(unlocalizedName)){
+    public static void RegisterFluid(Fluid fluid, @Nullable Item bucket, String MODID, String unlocalizedName, boolean isGaseous, int density, MapColor color, @Nullable CreativeTabs tab) {
+        if (usedNames.contains(unlocalizedName)) {
             DebugUtil.println("ERROR: ", "attempted to register Fluid with a used unlocalizedName", unlocalizedName);
             DebugUtil.throwStackTrace();
         }
-        if (!unlocalizedName.equals("")){
+        if (!unlocalizedName.equals("")) {
             fluid.setUnlocalizedName(unlocalizedName);
             usedNames.add(unlocalizedName);
         } else {
@@ -214,15 +214,15 @@ public class TiMGenericRegistry {
         fluid.setGaseous(isGaseous).setDensity(density);
         FluidRegistry.registerFluid(fluid);
 
-        Block block = new BlockTrainFluid(fluid, new MaterialLiquid(color)).setBlockName("block."+unlocalizedName.replace(".item","")).setBlockTextureName(MODID+":block_"+unlocalizedName);
-        ((BlockTrainFluid)block).setModID(MODID);
-        GameRegistry.registerBlock(block, "block."+unlocalizedName);
-        if(TrainsInMotion.proxy.isClient()){
-            block.setBlockTextureName(MODID+":"+unlocalizedName);
+        Block block = new BlockTrainFluid(fluid, new MaterialLiquid(color)).setBlockName("block." + unlocalizedName.replace(".item", "")).setBlockTextureName(MODID + ":block_" + unlocalizedName);
+        ((BlockTrainFluid) block).setModID(MODID);
+        GameRegistry.registerBlock(block, "block." + unlocalizedName);
+        if (TrainsInMotion.proxy.isClient()) {
+            block.setBlockTextureName(MODID + ":" + unlocalizedName);
         }
         fluid.setBlock(block);
 
-        if(bucket==null) {
+        if (bucket == null) {
             bucket = new ItemBucket(block).setCreativeTab(tab).setContainerItem(Items.bucket);
             if (TrainsInMotion.proxy.isClient()) {
                 bucket.setTextureName(MODID + ":bucket_" + unlocalizedName);
@@ -233,14 +233,14 @@ public class TiMGenericRegistry {
         FluidContainerRegistry.registerFluidContainer(fluid, new ItemStack(bucket), new ItemStack(Items.bucket));
 
 
-        if (DebugUtil.dev() && TrainsInMotion.proxy.isClient()){
-            if(fluid.getUnlocalizedName().equals(StatCollector.translateToLocal(fluid.getUnlocalizedName()))) {
+        if (DebugUtil.dev() && TrainsInMotion.proxy.isClient()) {
+            if (fluid.getUnlocalizedName().equals(StatCollector.translateToLocal(fluid.getUnlocalizedName()))) {
                 DebugUtil.println("Fluid missing lang entry: " + fluid.getUnlocalizedName());
             }
             if (bucket.getUnlocalizedName().equals(StatCollector.translateToLocal(block.getUnlocalizedName()))) {
                 DebugUtil.println("Item missing lang entry: " + bucket.getUnlocalizedName());
             }
-            if(block.getUnlocalizedName().equals(StatCollector.translateToLocal(block.getUnlocalizedName()))){
+            if (block.getUnlocalizedName().equals(StatCollector.translateToLocal(block.getUnlocalizedName()))) {
                 DebugUtil.println("Block missing lang entry: " + block.getUnlocalizedName());
             }
 
@@ -248,22 +248,22 @@ public class TiMGenericRegistry {
     }
 
 
-    public static void registerTransports(String MODID, GenericRailTransport[] entities, Object entityRender){
-        if(registryPosition==-1){
+    public static void registerTransports(String MODID, GenericRailTransport[] entities, Object entityRender) {
+        if (registryPosition == -1) {
             DebugUtil.println("ERROR", "ADDING TRANSPORT REGISTRY ITEMS OUTSIDE MOD INIT", "PLEASE REGISTER YOUR ENTITIES IN THE FOLLOWING EVENT:",
                     "@Mod.EventHandler public void init(FMLInitializationEvent event)");
         }
         for (GenericRailTransport registry : entities) {
-            if(DebugUtil.dev() && usedNames.contains(registry.transportName())){
-                DebugUtil.println(registry.getClass().getName(),"is trying to register under the name", usedNames.contains(registry.transportName()), "which is already used");
+            if (DebugUtil.dev() && usedNames.contains(registry.transportName())) {
+                DebugUtil.println(registry.getClass().getName(), "is trying to register under the name", usedNames.contains(registry.transportName()), "which is already used");
                 DebugUtil.throwStackTrace();
             }
             cpw.mods.fml.common.registry.EntityRegistry.registerModEntity(
                     registry.getClass(),
-                    registry.transportName().replace(" ","") + ".entity",
+                    registry.transportName().replace(" ", "") + ".entity",
                     registryPosition, TrainsInMotion.instance, 1600, 3, true);
             GameRegistry.registerItem(registry.getCartItem().getItem(), registry.getCartItem().getItem().getUnlocalizedName());
-            if(registry.getRecipe()!=null) {
+            if (registry.getRecipe() != null) {
                 if (CommonProxy.recipesInMods.containsKey(MODID)) {
                     CommonProxy.recipesInMods.get(MODID).add(getRecipeWithTier(registry.getRecipe(), registry.getCartItem(), registry.getTier()));
                 } else {
@@ -271,22 +271,22 @@ public class TiMGenericRegistry {
                     CommonProxy.recipesInMods.get(MODID).add(getRecipeWithTier(registry.getRecipe(), registry.getCartItem(), registry.getTier()));
                 }
             }
-            if(TrainsInMotion.proxy.isClient() && ClientProxy.hdTransportItems){
+            if (TrainsInMotion.proxy.isClient() && ClientProxy.hdTransportItems) {
                 MinecraftForgeClient.registerItemRenderer(registry.getCartItem().getItem(), ebf.tim.items.CustomItemModel.instance);
             }
             registry.registerSkins();
-            if(registry.getRecipe()!=null){
+            if (registry.getRecipe() != null) {
                 RecipeManager.registerRecipe(registry.getRecipe(), registry.getCartItem(), registry.getTier());
             }
             ItemCraftGuide.itemEntries.add(registry.getClass());
-            if(TrainsInMotion.proxy.isClient()) {
+            if (TrainsInMotion.proxy.isClient()) {
                 if (entityRender == null) {
-                    cpw.mods.fml.client.registry.RenderingRegistry.registerEntityRenderingHandler(registry.getClass(), (net.minecraft.client.renderer.entity.Render)TrainsInMotion.proxy.getEntityRender());
+                    cpw.mods.fml.client.registry.RenderingRegistry.registerEntityRenderingHandler(registry.getClass(), (net.minecraft.client.renderer.entity.Render) TrainsInMotion.proxy.getEntityRender());
                     if (ClientProxy.preRenderModels) {
                         ((net.minecraft.client.renderer.entity.Render) TrainsInMotion.proxy.getEntityRender()).doRender(registry, 0, 0, 0, 0, 0);
                     }
                 } else {
-                    cpw.mods.fml.client.registry.RenderingRegistry.registerEntityRenderingHandler(registry.getClass(), (net.minecraft.client.renderer.entity.Render)entityRender);
+                    cpw.mods.fml.client.registry.RenderingRegistry.registerEntityRenderingHandler(registry.getClass(), (net.minecraft.client.renderer.entity.Render) entityRender);
                     if (ClientProxy.preRenderModels) {
                         ((net.minecraft.client.renderer.entity.Render) entityRender).doRender(registry, 0, 0, 0, 0, 0);
                     }
@@ -303,29 +303,28 @@ public class TiMGenericRegistry {
     /**
      * @param priority the priority to generate, higher numbers tend to generate after other mods.
      */
-    public static void registerOreGen(int priority, OreGen veinConfig){
-        GameRegistry.registerWorldGenerator(veinConfig,priority);
+    public static void registerOreGen(int priority, OreGen veinConfig) {
+        GameRegistry.registerWorldGenerator(veinConfig, priority);
     }
 
 
-    public static void endRegistration(){
-        usedNames =null; registryPosition=-1; redundantTiles=null;
+    public static void endRegistration() {
+        usedNames = null;
+        registryPosition = -1;
+        redundantTiles = null;
     }
 
 
     //todo:add support for buildcraft/railcraft burnable fluids
 
-	@Optional.Method(modid = "BuildCraft|Energy")
-    static void registerBCFluid(Fluid f, int powerPerCycle, int totalBurningTime){
-		BuildcraftFuelRegistry.fuel.addFuel(f, powerPerCycle, totalBurningTime);
-	}
+    @Optional.Method(modid = "BuildCraft|Energy")
+    static void registerBCFluid(Fluid f, int powerPerCycle, int totalBurningTime) {
+        BuildcraftFuelRegistry.fuel.addFuel(f, powerPerCycle, totalBurningTime);
+    }
 
-	@Optional.Method(modid = "Railcraft")
+    @Optional.Method(modid = "Railcraft")
     static void registerRCFluid(Fluid f, int totalBurningTime) {
-		FuelManager.addBoilerFuel(f, totalBurningTime);
-	}
-
-
-
+        FuelManager.addBoilerFuel(f, totalBurningTime);
+    }
 
 }

--- a/src/main/java/ebf/tim/registry/TiMGenericRegistry.java
+++ b/src/main/java/ebf/tim/registry/TiMGenericRegistry.java
@@ -1,7 +1,12 @@
 package ebf.tim.registry;
 
 
+import buildcraft.api.fuels.BuildcraftFuelRegistry;
+import buildcraft.api.fuels.IFuel;
+import buildcraft.core.lib.block.BlockBuildCraftFluid;
 import cpw.mods.fml.common.IWorldGenerator;
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.common.registry.GameRegistry;
 import ebf.tim.TrainsInMotion;
 import ebf.tim.blocks.BlockDynamic;
@@ -13,6 +18,7 @@ import ebf.tim.items.ItemCraftGuide;
 import ebf.tim.items.ItemTransport;
 import ebf.tim.utility.*;
 import fexcraft.tmt.slim.ModelBase;
+import mods.railcraft.api.fuel.FuelManager;
 import net.minecraft.block.Block;
 import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.MapColor;
@@ -42,10 +48,8 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.oredict.OreDictionary;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Random;
+import java.lang.reflect.Array;
+import java.util.*;
 
 import static ebf.tim.utility.RecipeManager.getRecipe;
 import static ebf.tim.utility.RecipeManager.getRecipeWithTier;
@@ -309,17 +313,19 @@ public class TiMGenericRegistry {
     }
 
 
-    /*todo:add support for buildcraft/railcraft burnable fluids
+    //todo:add support for buildcraft/railcraft burnable fluids
+
 	@Optional.Method(modid = "BuildCraft|Energy")
-	private void registerBCFluid(Fluid f, int powerPerCycle, int totalBurningTime){
+    static void registerBCFluid(Fluid f, int powerPerCycle, int totalBurningTime){
 		BuildcraftFuelRegistry.fuel.addFuel(f, powerPerCycle, totalBurningTime);
 	}
 
 	@Optional.Method(modid = "Railcraft")
-	private void registerRCFluid(Fluid f, int totalBurningTime) {
+    static void registerRCFluid(Fluid f, int totalBurningTime) {
 		FuelManager.addBoilerFuel(f, totalBurningTime);
 	}
-     */
+
+
 
 
 }

--- a/src/main/java/ebf/tim/utility/FuelHandler.java
+++ b/src/main/java/ebf/tim/utility/FuelHandler.java
@@ -77,8 +77,16 @@ public class FuelHandler{
 			if(FluidContainerRegistry.getFluidForFilledItem(itemStack)!=null &&
 					FluidContainerRegistry.getFluidForFilledItem(itemStack).getUnlocalizedName().toLowerCase().contains("diesel")){
 				return new FluidStack(TiMFluids.fluidDiesel,1000);
+			} else if (FluidContainerRegistry.getFluidForFilledItem(itemStack)!=null &&
+					FluidContainerRegistry.getFluidForFilledItem(itemStack).getUnlocalizedName().toLowerCase().contains("fueloil")) {
+				return new FluidStack(TiMFluids.fluidfueloil, 1000);
+			} else if (FluidContainerRegistry.getFluidForFilledItem(itemStack)!=null &&
+					FluidContainerRegistry.getFluidForFilledItem(itemStack).getUnlocalizedName().toLowerCase().contains("oil")) {
+				return new FluidStack(TiMFluids.fluidOil,1000);
+			} else if (FluidContainerRegistry.getFluidForFilledItem(itemStack)!=null &&
+					FluidContainerRegistry.getFluidForFilledItem(itemStack).getUnlocalizedName().toLowerCase().contains("fuel")) {
+				return new FluidStack(TiMFluids.fluidfueloil, 1000);
 			}
-
 		}
 		if(transport.getTypes().contains(TrainsInMotion.transportTypes.STEAM)){
 			if(FluidContainerRegistry.getFluidForFilledItem(itemStack)!=null &&

--- a/src/main/java/ebf/tim/utility/FuelHandler.java
+++ b/src/main/java/ebf/tim/utility/FuelHandler.java
@@ -85,7 +85,19 @@ public class FuelHandler{
 				return new FluidStack(TiMFluids.fluidOil,1000);
 			} else if (FluidContainerRegistry.getFluidForFilledItem(itemStack)!=null &&
 					FluidContainerRegistry.getFluidForFilledItem(itemStack).getUnlocalizedName().toLowerCase().contains("fuel")) {
-				return new FluidStack(TiMFluids.fluidfueloil, 1000);
+				return new FluidStack(TiMFluids.fluidBCFuel, 1000);
+			} else if (FluidContainerRegistry.getFluidForFilledItem(itemStack)!=null &&
+					FluidContainerRegistry.getFluidForFilledItem(itemStack).getUnlocalizedName().toLowerCase().contains("bioethanol")) {
+				return new FluidStack(TiMFluids.fluidEthanol, 1000);
+			} else if (FluidContainerRegistry.getFluidForFilledItem(itemStack)!=null &&
+					FluidContainerRegistry.getFluidForFilledItem(itemStack).getUnlocalizedName().toLowerCase().contains("biofuel")) {
+				return new FluidStack(TiMFluids.fluidBiofuel, 1000);
+			} else if (FluidContainerRegistry.getFluidForFilledItem(itemStack)!=null &&
+					FluidContainerRegistry.getFluidForFilledItem(itemStack).getUnlocalizedName().toLowerCase().contains("biodiesel")) {
+				return new FluidStack(TiMFluids.fluidBioDiesel, 1000);
+			} else if (FluidContainerRegistry.getFluidForFilledItem(itemStack)!=null &&
+					FluidContainerRegistry.getFluidForFilledItem(itemStack).getUnlocalizedName().toLowerCase().contains("biomass")) {
+				return new FluidStack(TiMFluids.fluidBiomass, 1000);
 			}
 		}
 		if(transport.getTypes().contains(TrainsInMotion.transportTypes.STEAM)){


### PR DESCRIPTION
Finished Fuel code for the trains and expanded TiMFluids to include more compatability. Also added compatability between BC+RC so you can use our fuels in their devices