### PR TITLE
Fix tileEntity not deleted on client side

### DIFF
--- a/src/main/java/ebf/tim/blocks/RailTileEntity.java
+++ b/src/main/java/ebf/tim/blocks/RailTileEntity.java
@@ -91,7 +91,7 @@ public class RailTileEntity extends TileEntity {
 
     @Override
     public boolean shouldRefresh(Block oldBlock, Block newBlock, int oldMeta, int newMeta, World world, int x, int y, int z) {
-        return oldMeta!=newMeta;
+        return (oldBlock != newBlock) || (oldMeta != newMeta);
     }
 
     @Override

--- a/src/main/java/ebf/tim/blocks/TileRenderFacing.java
+++ b/src/main/java/ebf/tim/blocks/TileRenderFacing.java
@@ -130,7 +130,7 @@ public class TileRenderFacing extends TileEntity {
 
     @Override
     public boolean shouldRefresh(Block oldBlock, Block newBlock, int oldMeta, int newMeta, World world, int x, int y, int z) {
-        return false;
+        return (newBlock != oldBlock);
     }
 
     @Override


### PR DESCRIPTION
TileRenderFacing and RailTileEntity were not deleted on client side when the associated block is destroyed.
- It create kind of "ghost" TileEntity on client side ( and sometimes rendering issues )

Fix :
- change shouldRefresh function to return true when the block change
 