### PR TITLE
[Cleanup] Route (Most) API Calls Through `CommonUtil.java`

### DIFF
--- a/src/main/java/mods/railcraft/api/signals/AbstractPair.java
+++ b/src/main/java/mods/railcraft/api/signals/AbstractPair.java
@@ -10,6 +10,7 @@ package mods.railcraft.api.signals;
 import com.google.common.collect.MapMaker;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import mods.railcraft.api.core.WorldCoordinate;
 import net.minecraft.block.Block;
 import net.minecraft.nbt.NBTTagCompound;
@@ -130,8 +131,8 @@ public abstract class AbstractPair {
                 if (!world.blockExists(x, y, z))
                     continue;
 
-                Block block = world.getBlock(x, y, z);
-                int meta = world.getBlockMetadata(x, y, z);
+                Block block = CommonUtil.getBlockAt(world, x, y, z);
+                int meta = CommonUtil.getBlockFacing(world, x, y, z);
                 if (!block.hasTileEntity(meta)) {
                     clearPairing(coord);
                     continue;
@@ -194,8 +195,8 @@ public abstract class AbstractPair {
         if (!world.blockExists(x, y, z))
             return null;
 
-        Block block = world.getBlock(x, y, z);
-        int meta = world.getBlockMetadata(x, y, z);
+        Block block = CommonUtil.getBlockAt(world, x, y, z);
+        int meta = CommonUtil.getBlockFacing(world, x, y, z);
         if (!block.hasTileEntity(meta)) {
             pairingsToTest.add(coord);
             return null;

--- a/src/main/java/mods/railcraft/api/signals/SignalBlock.java
+++ b/src/main/java/mods/railcraft/api/signals/SignalBlock.java
@@ -8,6 +8,7 @@
  */
 package mods.railcraft.api.signals;
 
+import ebf.tim.utility.CommonUtil;
 import mods.railcraft.api.carts.CartTools;
 import mods.railcraft.api.core.WorldCoordinate;
 import mods.railcraft.api.tracks.RailTools;
@@ -17,7 +18,6 @@ import net.minecraft.entity.item.EntityMinecart;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -144,7 +144,7 @@ public abstract class SignalBlock extends AbstractPair {
             int y = other.y;
             int z = other.z;
 
-            Block block = tile.getWorldObj().getBlock(x, y, z);
+            Block block = CommonUtil.getBlockAt(tile.getWorldObj(), x, y, z);
             if (block != null)
                 log(DEBUG_LEVEL, "Signal Block target block [{0}, {1}, {2}] = {3}, {4}", x, y, z, block.getClass(), block.getUnlocalizedName());
             else
@@ -269,8 +269,8 @@ public abstract class SignalBlock extends AbstractPair {
 //        System.out.println("carts = " + carts.size());
         SignalAspect newAspect = SignalAspect.GREEN;
         for (EntityMinecart cart : carts) {
-            int cartX = MathHelper.floor_double(cart.posX);
-            int cartZ = MathHelper.floor_double(cart.posZ);
+            int cartX = CommonUtil.floorDouble(cart.posX);
+            int cartZ = CommonUtil.floorDouble(cart.posZ);
             if (Math.abs(cart.motionX) < 0.08 && Math.abs(cart.motionZ) < 0.08)
                 return SignalAspect.RED;
             else if (zAxis)

--- a/src/main/java/mods/railcraft/api/tracks/RailTools.java
+++ b/src/main/java/mods/railcraft/api/tracks/RailTools.java
@@ -8,12 +8,12 @@
 
 package mods.railcraft.api.tracks;
 
+import ebf.tim.utility.CommonUtil;
 import mods.railcraft.api.core.items.ITrackItem;
 import net.minecraft.block.BlockRailBase;
 import net.minecraft.entity.item.EntityMinecart;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import train.common.entity.rollingStockOld.special.EntityTracksBuilder;
@@ -75,9 +75,9 @@ public abstract class RailTools {
      * @return True if being held
      */
     public static boolean isCartLockedDown(EntityMinecart cart) {
-        int x = MathHelper.floor_double(cart.posX);
-        int y = MathHelper.floor_double(cart.posY);
-        int z = MathHelper.floor_double(cart.posZ);
+        int x = CommonUtil.floorDouble(cart.posX);
+        int y = CommonUtil.floorDouble(cart.posY);
+        int z = CommonUtil.floorDouble(cart.posZ);
 
         if (BlockRailBase.func_150049_b_(cart.worldObj, x, y - 1, z))
             y--;

--- a/src/main/java/mods/railcraft/api/tracks/TrackInstanceBase.java
+++ b/src/main/java/mods/railcraft/api/tracks/TrackInstanceBase.java
@@ -8,6 +8,7 @@
 
 package mods.railcraft.api.tracks;
 
+import ebf.tim.utility.CommonUtil;
 import mods.railcraft.api.core.items.IToolCrowbar;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockRailBase;
@@ -19,7 +20,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
@@ -46,7 +46,7 @@ public abstract class TrackInstanceBase implements ITrackInstance {
 
     private Block getBlock() {
         if (block == null)
-            block = getWorld().getBlock(getX(), getY(), getZ());
+            block = CommonUtil.getBlockAt(getWorld(), getX(), getY(), getZ());
         return block;
     }
 
@@ -106,7 +106,7 @@ public abstract class TrackInstanceBase implements ITrackInstance {
         if (entityliving == null)
             return;
         if (this instanceof ITrackReversable) {
-            int dir = MathHelper.floor_double((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
+            int dir = CommonUtil.floorDouble((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
             ((ITrackReversable) this).setReversed(dir == 0 || dir == 1);
         }
         markBlockNeedsUpdate();
@@ -121,7 +121,7 @@ public abstract class TrackInstanceBase implements ITrackInstance {
     }
 
     public void markBlockNeedsUpdate() {
-        getWorld().markBlockForUpdate(tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord);
+        CommonUtil.markBlockForUpdate(getWorld(), tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord);
     }
 
     protected boolean isRailValid(World world, int x, int y, int z, int meta) {
@@ -257,10 +257,10 @@ public abstract class TrackInstanceBase implements ITrackInstance {
 
     protected boolean testPowered(World world, int i, int j, int k, TrackSpec spec, boolean dir, int dist, int maxDist, int orientation) {
         // System.out.println("Testing Power at <" + i + ", " + j + ", " + k + ">");
-        Block blockToTest = world.getBlock(i, j, k);
+        Block blockToTest = CommonUtil.getBlockAt(world, i, j, k);
         Block blockTrack = getBlock();
         if (blockToTest == blockTrack) {
-            int meta = world.getBlockMetadata(i, j, k);
+            int meta = CommonUtil.getBlockFacing(world, i, j, k);
             TileEntity tile = world.getTileEntity(i, j, k);
             if (tile instanceof ITrackTile) {
                 ITrackInstance track = ((ITrackTile) tile).getTrackInstance();

--- a/src/main/java/train/client/core/handlers/CustomRenderHandler.java
+++ b/src/main/java/train/client/core/handlers/CustomRenderHandler.java
@@ -1,6 +1,7 @@
 package train.client.core.handlers;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityClientPlayerMP;
@@ -39,7 +40,7 @@ public class CustomRenderHandler {
         int y = Minecraft.getMinecraft().objectMouseOver.blockY;
         int z = Minecraft.getMinecraft().objectMouseOver.blockZ;
 
-        if (world.getBlock(x, y, z) == Blocks.air) {
+        if (CommonUtil.getBlockAt(world, x, y, z) == Blocks.air) {
             return;
         }
 
@@ -61,8 +62,8 @@ public class CustomRenderHandler {
         double py = TileEntityRendererDispatcher.staticPlayerY;
         double pz = TileEntityRendererDispatcher.staticPlayerZ;
         int facing = item.getTrackType().getRailType() == TCRailTypes.RailTypes.DIAGONAL
-                ? (MathHelper.floor_double(player.rotationYaw * 4.0F / 360.0F) & 3) + 4
-                : MathHelper.floor_double(player.rotationYaw * 4.0F / 360.0F + 0.5D) & 3;
+                ? (CommonUtil.floorDouble(player.rotationYaw * 4.0F / 360.0F) & 3) + 4
+                : CommonUtil.floorDouble(player.rotationYaw * 4.0F / 360.0F + 0.5D) & 3;
         Vector2f dir = ItemTCRail.getDirectionVector(facing);
         String variant = item.getTrackType().getLabel().contains("EMBEDDED") ? "embedded" : "normal";
 
@@ -421,8 +422,8 @@ public class CustomRenderHandler {
         int x = Minecraft.getMinecraft().objectMouseOver.blockX;
         int y = Minecraft.getMinecraft().objectMouseOver.blockY;
         int z = Minecraft.getMinecraft().objectMouseOver.blockZ;
-        Block block = world.getBlock(x, y, z);
-        int metadata = world.getBlockMetadata(x, y, z);
+        Block block = CommonUtil.getBlockAt(world, x, y, z);
+        int metadata = CommonUtil.getBlockFacing(world, x, y, z);
 
         blockColour = block.colorMultiplier(world, x, y, z);
         IIcon icon = block.getIcon(1, metadata);

--- a/src/main/java/train/client/gui/GuiAbstractPaintbrush.java
+++ b/src/main/java/train/client/gui/GuiAbstractPaintbrush.java
@@ -2,6 +2,7 @@ package train.client.gui;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
@@ -145,7 +146,7 @@ public abstract class GuiAbstractPaintbrush extends GuiScreen {
     @Override
     protected void actionPerformed(GuiButton clickedButton) {
         if (clickedButton.enabled) {
-            editingPlayer.playSound("random.click", 1f, 1f);
+            CommonUtil.playSound(editingPlayer, "random.click", 1f, 1f);
             // Select Color
             if (clickedButton.id < 3) { // Page up or down button.
                 if (clickedButton.id == 0) { // If page up...

--- a/src/main/java/train/client/gui/GuiAbstractPaintbrush.java
+++ b/src/main/java/train/client/gui/GuiAbstractPaintbrush.java
@@ -7,7 +7,6 @@ import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.StatCollector;
 import org.lwjgl.opengl.GL11;
 import train.common.api.EntityRollingStock;
 import train.common.library.Info;
@@ -134,11 +133,11 @@ public abstract class GuiAbstractPaintbrush extends GuiScreen {
         // I split this up to hopefully reduce the amount of statements it has to process.
         if (mouseX > closeMenuButton.xPosition - 5) { // If mouse is on the right-hand side after the textures.
             if (closeMenuButton.getTexture() == GuiButtonPaintbrushMenu.Texture.ACTIVE)
-                drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("paintbrushmenu.Close Menu.name")), mouseX, mouseY, fontRendererObj);
+                drawHoveringText(Collections.singletonList(CommonUtil.translate("paintbrushmenu.Close Menu.name")), mouseX, mouseY, fontRendererObj);
             else if (arrowUp.getTexture() == GuiButtonPaintbrushMenu.Texture.ACTIVE && arrowUp.visible)
-                drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("paintbrushmenu.Previous Page.name")), mouseX, mouseY, fontRendererObj);
+                drawHoveringText(Collections.singletonList(CommonUtil.translate("paintbrushmenu.Previous Page.name")), mouseX, mouseY, fontRendererObj);
             else if (arrowDown.getTexture() == GuiButtonPaintbrushMenu.Texture.ACTIVE && arrowDown.visible)
-                drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("paintbrushmenu.Next Page.name")), mouseX, mouseY, fontRendererObj);
+                drawHoveringText(Collections.singletonList(CommonUtil.translate("paintbrushmenu.Next Page.name")), mouseX, mouseY, fontRendererObj);
         }
         drawInForeground(mouseX, mouseY);
     }

--- a/src/main/java/train/client/gui/GuiBuilder.java
+++ b/src/main/java/train/client/gui/GuiBuilder.java
@@ -1,5 +1,6 @@
 package train.client.gui;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.Entity;
@@ -8,7 +9,6 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.StatCollector;
 import org.lwjgl.opengl.GL11;
 import train.common.Traincraft;
 import train.common.core.network.PacketSetTrainLockedToClient;
@@ -42,23 +42,23 @@ public class GuiBuilder extends GuiContainer {
         buttonList.clear();
 
         if ((builder).getFollowTracks() == 1) {
-            buttonList.add(new GuiButton(1, ((width - xSize) / 2) + 3, ((height - ySize) / 2) - 20, 80, 20, StatCollector.translateToLocal("builder.follow.name")));
+            buttonList.add(new GuiButton(1, ((width - xSize) / 2) + 3, ((height - ySize) / 2) - 20, 80, 20, CommonUtil.translate("builder.follow.name")));
         }
 
         if ((builder).getFollowTracks() == 0) {
-            buttonList.add(new GuiButton(1, ((width - xSize) / 2) + 3, ((height - ySize) / 2) - 20, 80, 20, StatCollector.translateToLocal("builder.remove.name")));
+            buttonList.add(new GuiButton(1, ((width - xSize) / 2) + 3, ((height - ySize) / 2) - 20, 80, 20, CommonUtil.translate("builder.remove.name")));
         }
 
-        buttonList.add(new GuiButton(2, ((width - xSize) / 2) + 85, ((height - ySize) / 2) - 40, 30, 20, StatCollector.translateToLocal("builder.up.name")));
-        buttonList.add(new GuiButton(3, ((width - xSize) / 2) + 85, ((height - ySize) / 2) - 20, 30, 20, StatCollector.translateToLocal("builder.down.name")));
+        buttonList.add(new GuiButton(2, ((width - xSize) / 2) + 85, ((height - ySize) / 2) - 40, 30, 20, CommonUtil.translate("builder.up.name")));
+        buttonList.add(new GuiButton(3, ((width - xSize) / 2) + 85, ((height - ySize) / 2) - 20, 30, 20, CommonUtil.translate("builder.down.name")));
 
         int buttonPosX = (this.width - xSize) / 2;
         int buttonPosY = (this.height - ySize) / 2;
 
         if (!(builder).getTrainLockedFromPacket()) {
-            this.buttonList.add(this.buttonLock = new GuiButton(4, buttonPosX + 3, buttonPosY - 30, 51, 10, StatCollector.translateToLocal("train.unlocked.name")));
+            this.buttonList.add(this.buttonLock = new GuiButton(4, buttonPosX + 3, buttonPosY - 30, 51, 10, CommonUtil.translate("train.unlocked.name")));
         } else {
-            this.buttonList.add(this.buttonLock = new GuiButton(4, buttonPosX + 3, buttonPosY - 30, 43, 10, StatCollector.translateToLocal("train.locked.name")));
+            this.buttonList.add(this.buttonLock = new GuiButton(4, buttonPosX + 3, buttonPosY - 30, 43, 10, CommonUtil.translate("train.locked.name")));
         }
     }
 
@@ -70,8 +70,8 @@ public class GuiBuilder extends GuiContainer {
         fontRendererObj.drawString("with new tracks", 4, 170, 0x404040);
         fontRendererObj.drawString("yet", 4, 180, 0x404040);
 
-        fontRendererObj.drawString(StatCollector.translateToLocal("builder.currElev.name") + ": " + (int) builder.currentHeight, 120, -25, 0xFFFFFF);
-        fontRendererObj.drawString(StatCollector.translateToLocal("builder.reqElev.name") + ": " + builder.getPlannedHeight(), 120, -10, 0xFFFFFF);
+        fontRendererObj.drawString(CommonUtil.translate("builder.currElev.name") + ": " + (int) builder.currentHeight, 120, -25, 0xFFFFFF);
+        fontRendererObj.drawString(CommonUtil.translate("builder.reqElev.name") + ": " + builder.getPlannedHeight(), 120, -10, 0xFFFFFF);
 
         if (intersectsWith(i, j)) {
             drawCreativeTabHoveringText("When a builder is locked,", i, j);
@@ -83,10 +83,10 @@ public class GuiBuilder extends GuiContainer {
         if (guibutton.id == 1) {
             if ((builder).getFollowTracks() == 1) {
                 sendFollow(0, builder.getEntityId());
-                guibutton.displayString = StatCollector.translateToLocal("builder.remove.name");
+                guibutton.displayString = CommonUtil.translate("builder.remove.name");
             } else {
                 sendFollow(1, builder.getEntityId());
-                guibutton.displayString = StatCollector.translateToLocal("builder.follow.name");
+                guibutton.displayString = CommonUtil.translate("builder.follow.name");
             }
         }
 
@@ -114,7 +114,7 @@ public class GuiBuilder extends GuiContainer {
                     }
 
                     builder.locked = true;
-                    guibutton.displayString = StatCollector.translateToLocal("train.locked.name");
+                    guibutton.displayString = CommonUtil.translate("train.locked.name");
                 } else {
                     if (lis3 != null && !lis3.isEmpty()) {
                         for (Object entity : lis3) {
@@ -125,12 +125,12 @@ public class GuiBuilder extends GuiContainer {
                     }
 
                     builder.locked = false;
-                    guibutton.displayString = StatCollector.translateToLocal("train.unlocked.name");
+                    guibutton.displayString = CommonUtil.translate("train.unlocked.name");
                 }
 
                 this.initGui();
             } else if (player != null) {
-                player.addChatMessage(new ChatComponentText(StatCollector.translateToLocal("train.owner.name")));
+                player.addChatMessage(new ChatComponentText(CommonUtil.translate("train.owner.name")));
             }
         }
     }

--- a/src/main/java/train/client/gui/GuiCraftingCart.java
+++ b/src/main/java/train/client/gui/GuiCraftingCart.java
@@ -1,9 +1,9 @@
 package train.client.gui;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import org.lwjgl.opengl.GL11;
 import train.common.containers.ContainerWorkbenchCart;
@@ -21,8 +21,8 @@ public class GuiCraftingCart extends GuiContainer {
 
     @Override
     protected void drawGuiContainerForegroundLayer(int i, int j) {
-        this.fontRendererObj.drawString(StatCollector.translateToLocal("container.crafting"), 28, 6, 4210752);
-        this.fontRendererObj.drawString(StatCollector.translateToLocal("container.inventory"), 8, this.ySize - 96 + 2, 4210752);
+        this.fontRendererObj.drawString(CommonUtil.translate("container.crafting"), 28, 6, 4210752);
+        this.fontRendererObj.drawString(CommonUtil.translate("container.inventory"), 8, this.ySize - 96 + 2, 4210752);
     }
 
     @Override

--- a/src/main/java/train/client/gui/GuiDynamicOverlay.java
+++ b/src/main/java/train/client/gui/GuiDynamicOverlay.java
@@ -2,6 +2,7 @@ package train.client.gui;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
@@ -280,7 +281,7 @@ public class GuiDynamicOverlay extends GuiScreen {
     @Override
     protected void actionPerformed(GuiButton clickedButton) {
         if (clickedButton.enabled) {
-            editingPlayer.playSound("random.click", 1f, 1f);
+            CommonUtil.playSound(editingPlayer, "random.click", 1f, 1f);
             switch (clickedButton.id) {
                 case 0: // Color Selection Grid Button
                     int x = mouseX - COLORGRID_ANCHOR_X_TOPLEFT;

--- a/src/main/java/train/client/gui/GuiDynamicOverlay.java
+++ b/src/main/java/train/client/gui/GuiDynamicOverlay.java
@@ -8,7 +8,6 @@ import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.StatCollector;
 import org.lwjgl.opengl.GL11;
 import train.common.Traincraft;
 import train.common.api.EntityRollingStock;
@@ -269,13 +268,13 @@ public class GuiDynamicOverlay extends GuiScreen {
 
         // Draw Hovering Tooltips
         if (mouseX > backgroundButton.xPosition && mouseX < backgroundButton.xPosition + backgroundButton.width && mouseY > backgroundButton.yPosition && mouseY < backgroundButton.yPosition + backgroundButton.height)
-            drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("dynamicoverlaymenu.Background Color.name")), mouseX, mouseY, fontRendererObj);
+            drawHoveringText(Collections.singletonList(CommonUtil.translate("dynamicoverlaymenu.Background Color.name")), mouseX, mouseY, fontRendererObj);
         else if (mouseX > foregroundButton.xPosition && mouseX < foregroundButton.xPosition + foregroundButton.width && mouseY > foregroundButton.yPosition && mouseY < foregroundButton.yPosition + foregroundButton.height)
-            drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("dynamicoverlaymenu.Foreground Color.name")), mouseX, mouseY, fontRendererObj);
+            drawHoveringText(Collections.singletonList(CommonUtil.translate("dynamicoverlaymenu.Foreground Color.name")), mouseX, mouseY, fontRendererObj);
         else if (mouseX > submitButton.xPosition && mouseX < submitButton.xPosition + submitButton.width && mouseY > submitButton.yPosition && mouseY < submitButton.yPosition + submitButton.height)
-            drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("dynamicoverlaymenu.Submit.name")), mouseX, mouseY, fontRendererObj);
+            drawHoveringText(Collections.singletonList(CommonUtil.translate("dynamicoverlaymenu.Submit.name")), mouseX, mouseY, fontRendererObj);
         else if (mouseX > cancelButton.xPosition && mouseX < cancelButton.xPosition + cancelButton.width && mouseY > cancelButton.yPosition && mouseY < cancelButton.yPosition + cancelButton.height)
-            drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("dynamicoverlaymenu.Back.name")), mouseX, mouseY, fontRendererObj);
+            drawHoveringText(Collections.singletonList(CommonUtil.translate("dynamicoverlaymenu.Back.name")), mouseX, mouseY, fontRendererObj);
     }
 
     @Override

--- a/src/main/java/train/client/gui/GuiFurnaceCart.java
+++ b/src/main/java/train/client/gui/GuiFurnaceCart.java
@@ -1,10 +1,10 @@
 package train.client.gui;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.StatCollector;
 import org.lwjgl.opengl.GL11;
 import train.common.api.AbstractWorkCart;
 import train.common.inventory.InventoryWorkCart;
@@ -20,8 +20,8 @@ public class GuiFurnaceCart extends GuiContainer {
 
     @Override
     protected void drawGuiContainerForegroundLayer(int i, int j) {
-        this.fontRendererObj.drawString(StatCollector.translateToLocal("container.furnace"), 60, 6, 4210752);
-        this.fontRendererObj.drawString(StatCollector.translateToLocal("container.inventory"), 8, this.ySize - 96 + 2, 4210752);
+        this.fontRendererObj.drawString(CommonUtil.translate("container.furnace"), 60, 6, 4210752);
+        this.fontRendererObj.drawString(CommonUtil.translate("container.inventory"), 8, this.ySize - 96 + 2, 4210752);
     }
 
     @Override

--- a/src/main/java/train/client/gui/GuiLiquid.java
+++ b/src/main/java/train/client/gui/GuiLiquid.java
@@ -1,5 +1,6 @@
 package train.client.gui;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.Entity;
@@ -8,7 +9,6 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.StatCollector;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import org.lwjgl.opengl.GL11;
@@ -41,7 +41,7 @@ public class GuiLiquid extends GuiContainer {
 
         if (intersectsWith(t, g)) {
             if (liquid.getLiquidName() != null && !liquid.getLiquidName().isEmpty()) {
-                drawCreativeTabHoveringText(StatCollector.translateToLocal(liquid.getLiquidName()) + ": " + liquid.getAmount() + "mb/" + liquid.getCapacity() + "mb", t, g);
+                drawCreativeTabHoveringText(CommonUtil.translate(liquid.getLiquidName()) + ": " + liquid.getAmount() + "mb/" + liquid.getCapacity() + "mb", t, g);
             } else {
                 drawCreativeTabHoveringText("0mb/" + liquid.getCapacity() + "mb", t, g);
             }

--- a/src/main/java/train/client/gui/GuiLockMenuAbstract.java
+++ b/src/main/java/train/client/gui/GuiLockMenuAbstract.java
@@ -8,7 +8,6 @@ import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.GuiTextField;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.StatCollector;
 import org.lwjgl.input.Mouse;
 import train.common.core.handlers.ConfigHandler;
 import train.common.entity.TrustedPlayer;
@@ -166,16 +165,16 @@ public abstract class GuiLockMenuAbstract extends GuiScreen {
         for (int i = 0; i < numberOfActiveTextboxes; i++) {
             textFieldList.get(i).drawTextBox();
         }
-        fontRendererObj.drawString(StatCollector.translateToLocal("lockmenu.Title_Trusted_Players.name"), GUI_ANCHOR_MID_X - (fontRendererObj.getStringWidth(StatCollector.translateToLocal("lockmenu.Title_Trusted_Players.name")) / 2), GUI_ANCHOR_Y + 40, -16777216);
+        fontRendererObj.drawString(CommonUtil.translate("lockmenu.Title_Trusted_Players.name"), GUI_ANCHOR_MID_X - (fontRendererObj.getStringWidth(CommonUtil.translate("lockmenu.Title_Trusted_Players.name")) / 2), GUI_ANCHOR_Y + 40, -16777216);
         if (lockUnlockButton.getTexture() == GuiButtonLockMenu.Texture.ACTIVE)
             if (getLocked())
-                drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("lockmenu.Unlock.name")), mouseX, mouseY, fontRendererObj);
+                drawHoveringText(Collections.singletonList(CommonUtil.translate("lockmenu.Unlock.name")), mouseX, mouseY, fontRendererObj);
             else
-                drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("lockmenu.Lock.name")), mouseX, mouseY, fontRendererObj);
+                drawHoveringText(Collections.singletonList(CommonUtil.translate("lockmenu.Lock.name")), mouseX, mouseY, fontRendererObj);
         if (closeButton.getTexture() == GuiButtonLockMenu.Texture.ACTIVE)
-            drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("lockmenu.Save and Close.name")), mouseX, mouseY, fontRendererObj);
+            drawHoveringText(Collections.singletonList(CommonUtil.translate("lockmenu.Save and Close.name")), mouseX, mouseY, fontRendererObj);
         if (closeAndSavetoAll.getTexture() == GuiButtonLockMenu.Texture.ACTIVE)
-            drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("lockmenu.Save To All Cars in Consist.name")), mouseX, mouseY, fontRendererObj);
+            drawHoveringText(Collections.singletonList(CommonUtil.translate("lockmenu.Save To All Cars in Consist.name")), mouseX, mouseY, fontRendererObj);
     }
 
     @Override

--- a/src/main/java/train/client/gui/GuiLockMenuAbstract.java
+++ b/src/main/java/train/client/gui/GuiLockMenuAbstract.java
@@ -2,6 +2,7 @@ package train.client.gui;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.GuiTextField;
@@ -180,7 +181,7 @@ public abstract class GuiLockMenuAbstract extends GuiScreen {
     @Override
     protected void actionPerformed(GuiButton clickedButton) {
         if (clickedButton.enabled) {
-            editingPlayer.playSound("random.click", 1f, 1f);
+            CommonUtil.playSound(editingPlayer, "random.click", 1f, 1f);
             switch (clickedButton.id) {
                 case 0:  // Main Lock Button
                     setLocked(!getLocked());

--- a/src/main/java/train/client/gui/GuiLoco2.java
+++ b/src/main/java/train/client/gui/GuiLoco2.java
@@ -3,6 +3,7 @@ package train.client.gui;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import ebf.tim.gui.GUIButton;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.inventory.GuiContainer;
@@ -11,7 +12,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.StatCollector;
 import org.lwjgl.opengl.GL11;
 import train.common.Traincraft;
 import train.common.api.*;
@@ -356,7 +356,7 @@ public class GuiLoco2 extends GuiContainer {
             int k = (height - ySize) / 2;
             if (mouseX > j + 143 && mouseX < j + 161 && mouseY > k + 18 && mouseY < k + 68) {
                 if (((DieselTrain) loco).getDiesel() != 0) {
-                    drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("fluid.tc:" + ((DieselTrain) loco).getLiquidName()) + " " +
+                    drawHoveringText(Collections.singletonList(CommonUtil.translate("fluid.tc:" + ((DieselTrain) loco).getLiquidName()) + " " +
                                     ((DieselTrain) loco).getDiesel() + "mb / " + (((DieselTrain) loco).getCartTankCapacity()) + "mb"),
                             mouseX, mouseY, fontRendererObj);
                 } else {

--- a/src/main/java/train/client/gui/GuiPaintbrushMenu.java
+++ b/src/main/java/train/client/gui/GuiPaintbrushMenu.java
@@ -4,6 +4,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import ebf.tim.api.SkinRegistry;
 import ebf.tim.api.TransportSkin;
+import ebf.tim.utility.CommonUtil;
 import ebf.tim.utility.DebugUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
@@ -436,7 +437,7 @@ public class GuiPaintbrushMenu extends GuiScreen {
     @Override
     protected void actionPerformed(GuiButton clickedButton) {
         if (clickedButton.enabled) {
-            editingPlayer.playSound("random.click", 1f, 1f);
+            CommonUtil.playSound(editingPlayer, "random.click", 1f, 1f);
             // Select Color
             switch (clickedButton.id) {
                 case 0:
@@ -617,7 +618,7 @@ public class GuiPaintbrushMenu extends GuiScreen {
             }
             updateSelectedTextureProperties();
             updateButtons();
-            editingPlayer.playSound("random.click", 1f, 1f);
+            CommonUtil.playSound(editingPlayer, "random.click", 1f, 1f);
         }
     }
 

--- a/src/main/java/train/client/gui/GuiPaintbrushMenu.java
+++ b/src/main/java/train/client/gui/GuiPaintbrushMenu.java
@@ -13,7 +13,6 @@ import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
@@ -377,16 +376,16 @@ public class GuiPaintbrushMenu extends GuiScreen {
                 case 0:
                 case 1: // Arrow left or right button.
                     if (GuiPaintbrushMenu.activeButtonID == 0) { // If arrow left...
-                        drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("paintbrushmenu.Previous Page.name")), mouseX, mouseY, fontRendererObj);
+                        drawHoveringText(Collections.singletonList(CommonUtil.translate("paintbrushmenu.Previous Page.name")), mouseX, mouseY, fontRendererObj);
                     } else { // If arrow right...
-                        drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("paintbrushmenu.Next Page.name")), mouseX, mouseY, fontRendererObj);
+                        drawHoveringText(Collections.singletonList(CommonUtil.translate("paintbrushmenu.Next Page.name")), mouseX, mouseY, fontRendererObj);
                     }
                     break;
                 case 2: // Render models button.
                     if (renderModels) {
-                        drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("paintbrushmenu.Hide Models.name")), mouseX, mouseY, fontRendererObj);
+                        drawHoveringText(Collections.singletonList(CommonUtil.translate("paintbrushmenu.Hide Models.name")), mouseX, mouseY, fontRendererObj);
                     } else {
-                        drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("paintbrushmenu.Show Models.name")), mouseX, mouseY, fontRendererObj);
+                        drawHoveringText(Collections.singletonList(CommonUtil.translate("paintbrushmenu.Show Models.name")), mouseX, mouseY, fontRendererObj);
                     }
                     break;
                 case 3: // Left texture button.
@@ -394,40 +393,40 @@ public class GuiPaintbrushMenu extends GuiScreen {
                 case 5: // Right texture button.
                     break;
                 case 6: // Random texture button.
-                    drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("paintbrushmenu.Random Texture.name")), mouseX, mouseY, fontRendererObj);
+                    drawHoveringText(Collections.singletonList(CommonUtil.translate("paintbrushmenu.Random Texture.name")), mouseX, mouseY, fontRendererObj);
                     break;
                 case 7: // Apply & submit button.
-                    drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("paintbrushmenu.Apply Texture.name")), mouseX, mouseY, fontRendererObj);
+                    drawHoveringText(Collections.singletonList(CommonUtil.translate("paintbrushmenu.Apply Texture.name")), mouseX, mouseY, fontRendererObj);
                     break;
                 case 8: // Description arrow up.
                 case 9: // Description arrow down.
                     break;
                 case 11: // Clear overlay button.
-                    drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("paintbrushmenu.None.name")), mouseX, mouseY, fontRendererObj);
+                    drawHoveringText(Collections.singletonList(CommonUtil.translate("paintbrushmenu.None.name")), mouseX, mouseY, fontRendererObj);
                     break;
                 case 12: // Open dynamic overlay menu button.
-                    drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("paintbrushmenu.Dynamic Overlay.name")), mouseX, mouseY, fontRendererObj);
+                    drawHoveringText(Collections.singletonList(CommonUtil.translate("paintbrushmenu.Dynamic Overlay.name")), mouseX, mouseY, fontRendererObj);
                     break;
                 case 13: // Open fixed overlay menu button.
-                    drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("paintbrushmenu.Fixed Overlay.name")), mouseX, mouseY, fontRendererObj);
+                    drawHoveringText(Collections.singletonList(CommonUtil.translate("paintbrushmenu.Fixed Overlay.name")), mouseX, mouseY, fontRendererObj);
                     break;
                 case 14: // Close button.
-                    drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("paintbrushmenu.Close Menu.name")), mouseX, mouseY, fontRendererObj);
+                    drawHoveringText(Collections.singletonList(CommonUtil.translate("paintbrushmenu.Close Menu.name")), mouseX, mouseY, fontRendererObj);
                     break;
                 case 15: // Pause/Play
                     if (doAnimation)
-                        drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("paintbrushmenu.Pause.name")), mouseX, mouseY, fontRendererObj);
+                        drawHoveringText(Collections.singletonList(CommonUtil.translate("paintbrushmenu.Pause.name")), mouseX, mouseY, fontRendererObj);
                     else
-                        drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("paintbrushmenu.Play.name")), mouseX, mouseY, fontRendererObj);
+                        drawHoveringText(Collections.singletonList(CommonUtil.translate("paintbrushmenu.Play.name")), mouseX, mouseY, fontRendererObj);
                     break;
                 case 17: //dropdown
-                    drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("paintbrushmenu.List Skins.name")), mouseX, mouseY, fontRendererObj);
+                    drawHoveringText(Collections.singletonList(CommonUtil.translate("paintbrushmenu.List Skins.name")), mouseX, mouseY, fontRendererObj);
                     break;
                 case 18: //dropdown UP
-                    drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("paintbrushmenu.Scroll Up.name")), mouseX, mouseY, fontRendererObj);
+                    drawHoveringText(Collections.singletonList(CommonUtil.translate("paintbrushmenu.Scroll Up.name")), mouseX, mouseY, fontRendererObj);
                     break;
                 case 19: //dropdown DOWN
-                    drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("paintbrushmenu.Scroll Down.name")), mouseX, mouseY, fontRendererObj);
+                    drawHoveringText(Collections.singletonList(CommonUtil.translate("paintbrushmenu.Scroll Down.name")), mouseX, mouseY, fontRendererObj);
                     break;
             }
 
@@ -656,14 +655,14 @@ public class GuiPaintbrushMenu extends GuiScreen {
             } else if (rollingStock.textureDescriptionMap.containsKey("Default")) {
                 currentDisplayTextureDescriptionString = rollingStock.textureDescriptionMap.get("Default").description;
             } else {
-                currentDisplayTextureDescriptionString = StatCollector.translateToLocal("paintbrushmenu.No Description.name");
+                currentDisplayTextureDescriptionString = CommonUtil.translate("paintbrushmenu.No Description.name");
             }
         } else {
             currentDisplayTextureTitle = currentDisplayTextureString;
             if (rollingStock.textureDescriptionMap.containsKey("Default")) {
                 currentDisplayTextureDescriptionString = rollingStock.textureDescriptionMap.get("Default").description;
             } else {
-                currentDisplayTextureDescriptionString = StatCollector.translateToLocal("paintbrushmenu.No Description.name");
+                currentDisplayTextureDescriptionString = CommonUtil.translate("paintbrushmenu.No Description.name");
             }
         }
         currentTextureDescription = Minecraft.getMinecraft().fontRenderer.listFormattedStringToWidth(currentDisplayTextureDescriptionString, (MENU_TEXTURE_WIDTH * 2) - 85);

--- a/src/main/java/train/client/gui/GuiRecipeBook.java
+++ b/src/main/java/train/client/gui/GuiRecipeBook.java
@@ -2,6 +2,7 @@ package train.client.gui;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.GuiTextField;
@@ -12,7 +13,6 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.StatCollector;
 import org.lwjgl.opengl.GL11;
 import train.client.core.handlers.RecipeBookHandler;
 import train.common.blocks.TCBlocks;
@@ -563,7 +563,7 @@ public class GuiRecipeBook extends GuiScreen {
 			this.drawTexturedModalRect(var5 - 55, var6 - 15, 0, 0, 256, 256);
 		}
 
-        pageIndic = String.format(StatCollector.translateToLocal("book.pageIndicator"), new Object[]{this.currPage + 1, this.bookTotalPages});
+        pageIndic = String.format(CommonUtil.translate("book.pageIndicator"), new Object[]{this.currPage + 1, this.bookTotalPages});
 
 		var9 = this.fontRendererObj.getStringWidth(pageIndic);
 		if (this.currPage > 0) {

--- a/src/main/java/train/client/gui/GuiTrainCraftingBlock.java
+++ b/src/main/java/train/client/gui/GuiTrainCraftingBlock.java
@@ -1,10 +1,10 @@
 package train.client.gui;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import org.lwjgl.opengl.GL11;
 import train.common.containers.ContainerTrainWorkbench;
@@ -18,7 +18,7 @@ public class GuiTrainCraftingBlock extends GuiContainer {
     @Override
     protected void drawGuiContainerForegroundLayer(int par1, int par2) {
         this.fontRendererObj.drawString("Train Workbench", 8, 6, 4210752);
-        this.fontRendererObj.drawString(StatCollector.translateToLocal("container.inventory"), 8, this.ySize - 96 + 2, 4210752);
+        this.fontRendererObj.drawString(CommonUtil.translate("container.inventory"), 8, this.ySize - 96 + 2, 4210752);
     }
 
     @Override

--- a/src/main/java/train/client/gui/sideTabs/SideTabRecipes.java
+++ b/src/main/java/train/client/gui/sideTabs/SideTabRecipes.java
@@ -9,10 +9,10 @@ package train.client.gui.sideTabs;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.item.Item;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.StatCollector;
 import org.lwjgl.opengl.GL11;
 import train.client.gui.GuiCrafterTier;
 import train.common.library.Info;
@@ -81,7 +81,7 @@ public class SideTabRecipes extends SideTab {
             }
 
             if (item != null) {
-                fontRenderer.drawString(StatCollector.translateToLocal(item.getUnlocalizedName()), x - 93, y + 78, headerColour);
+                fontRenderer.drawString(CommonUtil.translate(item.getUnlocalizedName()), x - 93, y + 78, headerColour);
                 gui.currentKnownItem = item;
             } else {
                 fontRenderer.drawString("Item name not found", x - 93, y + 78, headerColour);

--- a/src/main/java/train/client/render/RenderRollingStock.java
+++ b/src/main/java/train/client/render/RenderRollingStock.java
@@ -70,9 +70,9 @@ public class RenderRollingStock extends Render {
         y-=0.3f;
 
         GL11.glTranslatef((float) x, (float) y, (float) z);
-        int i = MathHelper.floor_double(cart.posX);
-        int j = MathHelper.floor_double(cart.posY);
-        int k = MathHelper.floor_double(cart.posZ);
+        int i = CommonUtil.floorDouble(cart.posX);
+        int j = CommonUtil.floorDouble(cart.posY);
+        int k = CommonUtil.floorDouble(cart.posZ);
 
         if (cart.worldObj != null && (CommonUtil.getBlockAt(cart.worldObj,i,j,k) instanceof BlockTCRail || CommonUtil.getBlockAt(cart.worldObj,i,j,k) instanceof BlockTCRailGag)) {
             GL11.glTranslatef(0f, 0.15f, 0f);
@@ -207,7 +207,7 @@ public class RenderRollingStock extends Render {
         }
     }
 
-    public static final float radianF = (float) Math.PI / 180.0f;
+    public static final float radianF = CommonUtil.radianF;
 
     public static double[] rotatePointF(double x, double y, double z, float pitch, float yaw) {
         double[] xyz = new double[]{x, y, z};

--- a/src/main/java/train/client/render/RenderRollingStock.java
+++ b/src/main/java/train/client/render/RenderRollingStock.java
@@ -238,7 +238,7 @@ public class RenderRollingStock extends Render {
     private static void renderExplosionFX(EntityRollingStock cart, float yaw, float pitch, String explosionType, List<double[]> explosionFX, int explosionFXIterations, boolean hasSmokeOnSlopes) {
         if (cart instanceof Locomotive && !((Locomotive) cart).isLocoTurnedOn()) return;
         float yawMod = yaw % 360;
-        double pitchRads = Math.toDegrees(pitch);
+        double pitchRads = pitch * CommonUtil.degreesD;
         //if (pitch != 0 && !hasSmokeOnSlopes) { return; }
         if (Math.abs(pitch) > 30) return;
         if (cart instanceof Locomotive && ((Locomotive) cart).getFuel() > 0) {

--- a/src/main/java/train/client/render/models/ModelLocoDieselIC4_DSB_FG.java
+++ b/src/main/java/train/client/render/models/ModelLocoDieselIC4_DSB_FG.java
@@ -15,7 +15,7 @@ import fexcraft.tmt.slim.ModelConverter;
 import fexcraft.tmt.slim.ModelRendererTurbo;
 import net.minecraft.entity.Entity;
 import org.lwjgl.opengl.GL11;
-import train.common.core.util.TraincraftUtil;
+import ebf.tim.utility.CommonUtil;
 
 public class ModelLocoDieselIC4_DSB_FG extends ModelConverter
 {
@@ -698,9 +698,9 @@ public class ModelLocoDieselIC4_DSB_FG extends ModelConverter
 
   private void setRotation(ModelRendererTurbo model, float x, float y, float z)
 	{
-		model.rotateAngleX = x* TraincraftUtil.degreesF;
-		model.rotateAngleY = y* TraincraftUtil.degreesF;
-		model.rotateAngleZ = z* TraincraftUtil.degreesF;
+		model.rotateAngleX = x* CommonUtil.degreesF;
+		model.rotateAngleY = y* CommonUtil.degreesF;
+		model.rotateAngleZ = z* CommonUtil.degreesF;
 	}
 
 

--- a/src/main/java/train/client/render/models/ModelLocoDieselIC4_DSB_FH.java
+++ b/src/main/java/train/client/render/models/ModelLocoDieselIC4_DSB_FH.java
@@ -7,7 +7,7 @@ import fexcraft.tmt.slim.ModelBase;
 import fexcraft.tmt.slim.ModelRendererTurbo;
 import net.minecraft.entity.Entity;
 import org.lwjgl.opengl.GL11;
-import train.common.core.util.TraincraftUtil;
+import ebf.tim.utility.CommonUtil;
 
 public class ModelLocoDieselIC4_DSB_FH extends ModelBase
 {
@@ -562,9 +562,9 @@ public class ModelLocoDieselIC4_DSB_FH extends ModelBase
 
 	private void setRotation(ModelRendererTurbo model, float x, float y, float z)
 	{
-		model.rotateAngleX = x* TraincraftUtil.degreesF;
-		model.rotateAngleY = y* TraincraftUtil.degreesF;
-		model.rotateAngleZ = z* TraincraftUtil.degreesF;
+		model.rotateAngleX = x* CommonUtil.degreesF;
+		model.rotateAngleY = y* CommonUtil.degreesF;
+		model.rotateAngleZ = z* CommonUtil.degreesF;
 	}
 
 }

--- a/src/main/java/train/client/render/models/ModelLocoDieselIC4_DSB_MG.java
+++ b/src/main/java/train/client/render/models/ModelLocoDieselIC4_DSB_MG.java
@@ -7,7 +7,7 @@ import fexcraft.tmt.slim.ModelBase;
 import fexcraft.tmt.slim.ModelRendererTurbo;
 import net.minecraft.entity.Entity;
 import org.lwjgl.opengl.GL11;
-import train.common.core.util.TraincraftUtil;
+import ebf.tim.utility.CommonUtil;
 
 public class ModelLocoDieselIC4_DSB_MG extends ModelBase
 {
@@ -978,9 +978,9 @@ public class ModelLocoDieselIC4_DSB_MG extends ModelBase
 
 	private void setRotation(ModelRendererTurbo model, float x, float y, float z)
 	{
-		model.rotateAngleX = x* TraincraftUtil.degreesF;
-		model.rotateAngleY = y* TraincraftUtil.degreesF;
-		model.rotateAngleZ = z* TraincraftUtil.degreesF;
+		model.rotateAngleX = x* CommonUtil.degreesF;
+		model.rotateAngleY = y* CommonUtil.degreesF;
+		model.rotateAngleZ = z* CommonUtil.degreesF;
 	}
 
 }

--- a/src/main/java/train/client/render/models/ModelLocoSteamAdler.java
+++ b/src/main/java/train/client/render/models/ModelLocoSteamAdler.java
@@ -11,7 +11,7 @@ import fexcraft.tmt.slim.ModelBase;
 import fexcraft.tmt.slim.ModelRendererTurbo;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
-import train.common.core.util.TraincraftUtil;
+import ebf.tim.utility.CommonUtil;
 
 public class ModelLocoSteamAdler extends ModelBase {
 
@@ -2207,8 +2207,8 @@ public class ModelLocoSteamAdler extends ModelBase {
 
 	private void setRotation(ModelRendererTurbo model, float x, float y, float z)
 	{
-		model.rotateAngleX = x* TraincraftUtil.degreesF;
-		model.rotateAngleY = y* TraincraftUtil.degreesF;
-		model.rotateAngleZ = z* TraincraftUtil.degreesF;
+		model.rotateAngleX = x* CommonUtil.degreesF;
+		model.rotateAngleY = y* CommonUtil.degreesF;
+		model.rotateAngleZ = z* CommonUtil.degreesF;
 	}
 }

--- a/src/main/java/train/client/render/models/ModelPassengerAdler.java
+++ b/src/main/java/train/client/render/models/ModelPassengerAdler.java
@@ -10,7 +10,7 @@ package train.client.render.models;
 import fexcraft.tmt.slim.ModelBase;
 import fexcraft.tmt.slim.ModelRendererTurbo;
 import net.minecraft.entity.Entity;
-import train.common.core.util.TraincraftUtil;
+import ebf.tim.utility.CommonUtil;
 
 public class ModelPassengerAdler extends ModelBase {
 
@@ -1714,8 +1714,8 @@ public class ModelPassengerAdler extends ModelBase {
 
 	private void setRotation(ModelRendererTurbo model, float x, float y, float z)
 	{
-		model.rotateAngleX = x* TraincraftUtil.degreesF;
-		model.rotateAngleY = y* TraincraftUtil.degreesF;
-		model.rotateAngleZ = z* TraincraftUtil.degreesF;
+		model.rotateAngleX = x* CommonUtil.degreesF;
+		model.rotateAngleY = y* CommonUtil.degreesF;
+		model.rotateAngleZ = z* CommonUtil.degreesF;
 	}
 }

--- a/src/main/java/train/client/render/models/ModelRotaryExcavator.java
+++ b/src/main/java/train/client/render/models/ModelRotaryExcavator.java
@@ -1,5 +1,6 @@
 package train.client.render.models;
 
+import ebf.tim.utility.CommonUtil;
 import fexcraft.tmt.slim.ModelBase;
 import net.minecraft.entity.Entity;
 import train.client.render.CustomModelRenderer;

--- a/src/main/java/train/client/render/models/ModelRotaryExcavator.java
+++ b/src/main/java/train/client/render/models/ModelRotaryExcavator.java
@@ -150,7 +150,7 @@ public class ModelRotaryExcavator extends ModelBase {
 		/**
 		 * Pitch
 		 */
-		float pitch = (float) Math.toRadians(((EntityRotativeDigger) entity).pitch);
+		float pitch = ((EntityRotativeDigger) entity).pitch * CommonUtil.radianF;
 
 		if (pitch > ((EntityRotativeDigger) entity).pitchLimits)
 			pitch = ((EntityRotativeDigger) entity).pitchLimits;

--- a/src/main/java/train/client/render/models/ModelTenderAdler.java
+++ b/src/main/java/train/client/render/models/ModelTenderAdler.java
@@ -11,7 +11,7 @@ package train.client.render.models;
 import fexcraft.tmt.slim.ModelBase;
 import fexcraft.tmt.slim.ModelRendererTurbo;
 import net.minecraft.entity.Entity;
-import train.common.core.util.TraincraftUtil;
+import ebf.tim.utility.CommonUtil;
 
 public class ModelTenderAdler extends ModelBase {
 
@@ -1459,8 +1459,8 @@ public class ModelTenderAdler extends ModelBase {
 	
 	private void setRotation(ModelRendererTurbo model, float x, float y, float z)
 	{
-		model.rotateAngleX = x* TraincraftUtil.degreesF;
-		model.rotateAngleY = y* TraincraftUtil.degreesF;
-		model.rotateAngleZ = z* TraincraftUtil.degreesF;
+		model.rotateAngleX = x* CommonUtil.degreesF;
+		model.rotateAngleY = y* CommonUtil.degreesF;
+		model.rotateAngleZ = z* CommonUtil.degreesF;
 	}
 }

--- a/src/main/java/train/client/render/models/blocks/ModelLargeSlopeTCTrack.java
+++ b/src/main/java/train/client/render/models/blocks/ModelLargeSlopeTCTrack.java
@@ -2,6 +2,7 @@ package train.client.render.models.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.util.IIcon;
@@ -102,7 +103,7 @@ public class ModelLargeSlopeTCTrack extends ModelBase {
 			colour = 16777215;
 		}
 
-		render( type, tcRail.getWorldObj().getBlockMetadata(tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1, iconName, colour);
+		render( type, CommonUtil.getBlockFacing(tcRail.getWorldObj(), tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1, iconName, colour);
 	}
 
 	public void render(String type, int facing, double x, double y, double z, float r, float g, float b, float a, String ballastTexture, int colour)

--- a/src/main/java/train/client/render/models/blocks/ModelLeft45DegreeTurnTCTrack.java
+++ b/src/main/java/train/client/render/models/blocks/ModelLeft45DegreeTurnTCTrack.java
@@ -2,6 +2,7 @@ package train.client.render.models.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.AdvancedModelLoader;
 import net.minecraftforge.client.model.IModelCustom;
@@ -41,7 +42,7 @@ public class ModelLeft45DegreeTurnTCTrack {
 
 
     public void render(String type,String variant, TileTCRail tcRail, double x, double y, double z) {
-        render( type, variant, tcRail.getWorldObj().getBlockMetadata(tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1);
+        render( type, variant, CommonUtil.getBlockFacing(tcRail.getWorldObj(), tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1);
     }
 
     public void render(String type, String variant ,int facing, double x, double y, double z, float r, float g, float b, float a) {

--- a/src/main/java/train/client/render/models/blocks/ModelLeftCurvedSlopeTCTrack.java
+++ b/src/main/java/train/client/render/models/blocks/ModelLeftCurvedSlopeTCTrack.java
@@ -1,6 +1,7 @@
 package train.client.render.models.blocks;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.util.IIcon;
@@ -131,7 +132,7 @@ public class ModelLeftCurvedSlopeTCTrack extends ModelBase {
             iconName = "tc:ballast_test";
             colour = 16777215;
         }
-        render( type, tcRail.getWorldObj().getBlockMetadata(tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1, iconName, colour);
+        render( type, CommonUtil.getBlockFacing(tcRail.getWorldObj(), tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1, iconName, colour);
 
     }
 

--- a/src/main/java/train/client/render/models/blocks/ModelLeftDiamondCrossing.java
+++ b/src/main/java/train/client/render/models/blocks/ModelLeftDiamondCrossing.java
@@ -2,6 +2,7 @@ package train.client.render.models.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.AdvancedModelLoader;
@@ -21,7 +22,7 @@ public class ModelLeftDiamondCrossing extends ModelBase{
     }
 
     public void render(String type, TileTCRail tcRail, double x, double y, double z) {
-        render(type, x, y, z, tcRail.getWorldObj().getBlockMetadata(tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), 1, 1, 1, 1);
+        render(type, x, y, z, CommonUtil.getBlockFacing(tcRail.getWorldObj(), tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), 1, 1, 1, 1);
     }
 
     public void render(String type , double x, double y, double z, int facing, float r, float g, float b, float a) {

--- a/src/main/java/train/client/render/models/blocks/ModelLeftParallelCurveTCTrack.java
+++ b/src/main/java/train/client/render/models/blocks/ModelLeftParallelCurveTCTrack.java
@@ -2,6 +2,7 @@ package train.client.render.models.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.AdvancedModelLoader;
@@ -32,7 +33,7 @@ public class ModelLeftParallelCurveTCTrack extends ModelBase {
     public void render20x2() {model20x2SCurveLeft.renderAll();}
 
     public void render(String type, String variant, TileTCRail tcRail, double x, double y, double z) {
-        render( type, variant, tcRail.getWorldObj().getBlockMetadata(tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1 );
+        render( type, variant, CommonUtil.getBlockFacing(tcRail.getWorldObj(), tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1 );
     }
 
     public void render(String type,String variant,int facing, double x, double y, double z, float r, float g, float b, float a) {

--- a/src/main/java/train/client/render/models/blocks/ModelLeftSwitchTCTrack.java
+++ b/src/main/java/train/client/render/models/blocks/ModelLeftSwitchTCTrack.java
@@ -2,6 +2,7 @@ package train.client.render.models.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.AdvancedModelLoader;
@@ -85,7 +86,7 @@ public class ModelLeftSwitchTCTrack extends ModelBase {
 	public void renderLarge45degreeInActive() {modelLargeLeft45degreeSwitchInActive.renderAll();}
 
 	public void render(String type, String variant, TileTCRail tcRail, double x, double y, double z) {
-		render( type, variant, tcRail.getWorldObj().getBlockMetadata(tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), tcRail.getSwitchState(), x, y, z, 1, 1, 1, 1);
+		render( type, variant, CommonUtil.getBlockFacing(tcRail.getWorldObj(), tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), tcRail.getSwitchState(), x, y, z, 1, 1, 1, 1);
 	}
 
 	public void render(String type, String variant, int facing, boolean active, double x, double y, double z, float r, float g, float b, float a) {

--- a/src/main/java/train/client/render/models/blocks/ModelLeftTurnTCTrack.java
+++ b/src/main/java/train/client/render/models/blocks/ModelLeftTurnTCTrack.java
@@ -2,6 +2,7 @@ package train.client.render.models.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.AdvancedModelLoader;
@@ -47,7 +48,7 @@ public class ModelLeftTurnTCTrack extends ModelBase {
 	public void render32X() {model32XLeftTurn.renderAll();}
 
 	public void render(String type, TileTCRail tcRail, double x, double y, double z) {
-		render( type, tcRail.getWorldObj().getBlockMetadata(tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1);
+		render( type, CommonUtil.getBlockFacing(tcRail.getWorldObj(), tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1);
 	}
 
 	public void render(String type, int facing, double x, double y, double z, float r, float g, float b, float a) {

--- a/src/main/java/train/client/render/models/blocks/ModelMediumDiagonalStraightTCTrack.java
+++ b/src/main/java/train/client/render/models/blocks/ModelMediumDiagonalStraightTCTrack.java
@@ -2,6 +2,7 @@ package train.client.render.models.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.AdvancedModelLoader;
@@ -27,7 +28,7 @@ public class ModelMediumDiagonalStraightTCTrack extends ModelBase {
     }
 
     public void render(String type, TileTCRail tcRail, double x, double y, double z) {
-        render( type, tcRail.getWorldObj().getBlockMetadata(tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1 );
+        render( type, CommonUtil.getBlockFacing(tcRail.getWorldObj(), tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1 );
     }
 
     public void render( String type, int facing, double x, double y, double z, float r, float g, float b, float a )

--- a/src/main/java/train/client/render/models/blocks/ModelMediumStraightTCTrack.java
+++ b/src/main/java/train/client/render/models/blocks/ModelMediumStraightTCTrack.java
@@ -2,6 +2,7 @@ package train.client.render.models.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.AdvancedModelLoader;
@@ -35,7 +36,7 @@ public class ModelMediumStraightTCTrack extends ModelBase {
 		GL11.glTranslatef((float) x + 0.5f, (float) y, (float) z + 0.5f);
 		GL11.glColor4f(1, 1, 1, 1);
 		//GL11.glScalef(0.5f, 0.5f, 0.5f);
-		int facing = tcRail.getWorldObj().getBlockMetadata(tcRail.xCoord, tcRail.yCoord, tcRail.zCoord);
+		int facing = CommonUtil.getBlockFacing(tcRail.getWorldObj(), tcRail.xCoord, tcRail.yCoord, tcRail.zCoord);
 
 		if (facing == 2) {
 			GL11.glRotatef(0, 0, 1, 0);

--- a/src/main/java/train/client/render/models/blocks/ModelRight45DegreeTurnTCTrack.java
+++ b/src/main/java/train/client/render/models/blocks/ModelRight45DegreeTurnTCTrack.java
@@ -2,6 +2,7 @@ package train.client.render.models.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.AdvancedModelLoader;
 import net.minecraftforge.client.model.IModelCustom;
@@ -37,7 +38,7 @@ public class ModelRight45DegreeTurnTCTrack {
     public void render10x22(){model10x22Right45DegreeTurn.renderAll();}
 
     public void render(String type, String variant, TileTCRail tcRail, double x, double y, double z) {
-        render( type, variant, tcRail.getWorldObj().getBlockMetadata(tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1);
+        render( type, variant, CommonUtil.getBlockFacing(tcRail.getWorldObj(), tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1);
     }
 
     public void render(String type, String variant, int facing, double x, double y, double z, float r, float g, float b, float a) {

--- a/src/main/java/train/client/render/models/blocks/ModelRightCurvedSlopeTCTrack.java
+++ b/src/main/java/train/client/render/models/blocks/ModelRightCurvedSlopeTCTrack.java
@@ -1,6 +1,7 @@
 package train.client.render.models.blocks;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.util.IIcon;
@@ -128,7 +129,7 @@ public class ModelRightCurvedSlopeTCTrack extends ModelBase {
             iconName = "tc:ballast_test";
             colour = 16777215;
         }
-        render( type, tcRail.getWorldObj().getBlockMetadata(tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1, iconName, colour);
+        render( type, CommonUtil.getBlockFacing(tcRail.getWorldObj(), tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1, iconName, colour);
 
     }
 

--- a/src/main/java/train/client/render/models/blocks/ModelRightDiamondCrossing.java
+++ b/src/main/java/train/client/render/models/blocks/ModelRightDiamondCrossing.java
@@ -2,6 +2,7 @@ package train.client.render.models.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.AdvancedModelLoader;
@@ -21,7 +22,7 @@ public class ModelRightDiamondCrossing extends ModelBase{
     }
 
     public void render(String type, TileTCRail tcRail, double x, double y, double z) {
-        render(type, x, y, z, tcRail.getWorldObj().getBlockMetadata(tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), 1, 1, 1, 1);
+        render(type, x, y, z, CommonUtil.getBlockFacing(tcRail.getWorldObj(), tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), 1, 1, 1, 1);
     }
 
     public void render(String type , double x, double y, double z,int facing, float r, float g, float b, float a) {

--- a/src/main/java/train/client/render/models/blocks/ModelRightParallelCurveTCTrack.java
+++ b/src/main/java/train/client/render/models/blocks/ModelRightParallelCurveTCTrack.java
@@ -2,6 +2,7 @@ package train.client.render.models.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.AdvancedModelLoader;
@@ -32,7 +33,7 @@ public class ModelRightParallelCurveTCTrack extends ModelBase {
     public void render20x2() {model20x2SCurveRight.renderAll();}
 
     public void render(String type, String variant, TileTCRail tcRail, double x, double y, double z) {
-        render( type, variant, tcRail.getWorldObj().getBlockMetadata(tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1 );
+        render( type, variant, CommonUtil.getBlockFacing(tcRail.getWorldObj(), tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1 );
     }
 
     public void render(String type, String variant, int facing, double x, double y, double z, float r, float g, float b, float a) {

--- a/src/main/java/train/client/render/models/blocks/ModelRightSwitchTCTrack.java
+++ b/src/main/java/train/client/render/models/blocks/ModelRightSwitchTCTrack.java
@@ -2,6 +2,7 @@ package train.client.render.models.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.AdvancedModelLoader;
@@ -89,7 +90,7 @@ public class ModelRightSwitchTCTrack extends ModelBase {
 	}
 
 	public void render(String type, String variant, TileTCRail tcRail, double x, double y, double z) {
-		render( type, variant, tcRail.getWorldObj().getBlockMetadata(tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), tcRail.getSwitchState(), x, y, z, 1, 1, 1, 1);
+		render( type, variant, CommonUtil.getBlockFacing(tcRail.getWorldObj(), tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), tcRail.getSwitchState(), x, y, z, 1, 1, 1, 1);
 	}
 
 	public void render(String type, String variant, int facing, boolean active, double x, double y, double z, float r, float g, float b, float a) {

--- a/src/main/java/train/client/render/models/blocks/ModelRightTurnTCTrack.java
+++ b/src/main/java/train/client/render/models/blocks/ModelRightTurnTCTrack.java
@@ -2,6 +2,7 @@ package train.client.render.models.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.AdvancedModelLoader;
@@ -50,7 +51,7 @@ public class ModelRightTurnTCTrack extends ModelBase {
 	public void render32X() {model32XRightTurn.renderAll();}
 
 	public void render(String type, TileTCRail tcRail, double x, double y, double z) {
-		render( type, tcRail.getWorldObj().getBlockMetadata(tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1);
+		render( type, CommonUtil.getBlockFacing(tcRail.getWorldObj(), tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1);
 	}
 
 	public void render(String type, int facing, double x, double y, double z, float r, float g, float b, float a) {

--- a/src/main/java/train/client/render/models/blocks/ModelSlopeTCTrack.java
+++ b/src/main/java/train/client/render/models/blocks/ModelSlopeTCTrack.java
@@ -2,6 +2,7 @@ package train.client.render.models.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.util.IIcon;
@@ -116,7 +117,7 @@ public class ModelSlopeTCTrack extends ModelBase {
 			iconName = "tc:ballast_test";
 			colour = 16777215;
 		}
-		render( type, tcRail.getWorldObj().getBlockMetadata(tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1, iconName, colour);
+		render( type, CommonUtil.getBlockFacing(tcRail.getWorldObj(), tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1, iconName, colour);
 
 	}
 

--- a/src/main/java/train/client/render/models/blocks/ModelSmallDiagonalStraightTCTrack.java
+++ b/src/main/java/train/client/render/models/blocks/ModelSmallDiagonalStraightTCTrack.java
@@ -2,6 +2,7 @@ package train.client.render.models.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.AdvancedModelLoader;
@@ -25,7 +26,7 @@ public class ModelSmallDiagonalStraightTCTrack extends ModelBase {
     }
 
     public void render(String type, TileTCRail tcRail, double x, double y, double z) {
-        render( type, tcRail.getWorldObj().getBlockMetadata(tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1 );
+        render( type, CommonUtil.getBlockFacing(tcRail.getWorldObj(), tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1 );
     }
 
     public void render( String type, int facing, double x, double y, double z, float r, float g, float b, float a )

--- a/src/main/java/train/client/render/models/blocks/ModelSmallStraightTCTrack.java
+++ b/src/main/java/train/client/render/models/blocks/ModelSmallStraightTCTrack.java
@@ -2,6 +2,7 @@ package train.client.render.models.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.util.IIcon;
@@ -46,7 +47,7 @@ public class ModelSmallStraightTCTrack extends ModelBase {
 		}
 
 
-		render( type, tcRail.getWorldObj().getBlockMetadata(tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1 , iconName, colour);
+		render( type, CommonUtil.getBlockFacing(tcRail.getWorldObj(), tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1 , iconName, colour);
 	}
 
 

--- a/src/main/java/train/client/render/models/blocks/ModelTwoWaysCrossingTCTrack.java
+++ b/src/main/java/train/client/render/models/blocks/ModelTwoWaysCrossingTCTrack.java
@@ -2,6 +2,7 @@ package train.client.render.models.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.AdvancedModelLoader;
@@ -38,7 +39,7 @@ public class ModelTwoWaysCrossingTCTrack extends ModelBase {
 
 
 	public void render(String type, TileTCRail tcRail,  double x, double y, double z) {
-		render(type, x, y, z, tcRail.getWorldObj().getBlockMetadata(tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), 1, 1, 1, 1);
+		render(type, x, y, z, CommonUtil.getBlockFacing(tcRail.getWorldObj(), tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), 1, 1, 1, 1);
 
 	}
 

--- a/src/main/java/train/client/render/models/blocks/ModelVeryLargeSlopeTCTrack.java
+++ b/src/main/java/train/client/render/models/blocks/ModelVeryLargeSlopeTCTrack.java
@@ -1,5 +1,6 @@
 package train.client.render.models.blocks;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.util.IIcon;
@@ -103,7 +104,7 @@ public class ModelVeryLargeSlopeTCTrack extends ModelBase {
 			colour = 16777215;
 		}
 
-		render( type, tcRail.getWorldObj().getBlockMetadata(tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1, iconName, colour);
+		render( type, CommonUtil.getBlockFacing(tcRail.getWorldObj(), tcRail.xCoord, tcRail.yCoord, tcRail.zCoord), x, y, z, 1, 1, 1, 1, iconName, colour);
 	}
 
 	public void render(String type, int facing, double x, double y, double z, float r, float g, float b, float a, String ballastTexture, int colour)

--- a/src/main/java/train/client/render/models/blocks/ModelWaterWheel.java
+++ b/src/main/java/train/client/render/models/blocks/ModelWaterWheel.java
@@ -2,6 +2,7 @@ package train.client.render.models.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.AdvancedModelLoader;
@@ -43,7 +44,7 @@ public class ModelWaterWheel extends ModelBase {
 		float f4 = (float) (j & 255) / 255.0F;
 		GL11.glColor4f(f1 * f2, f1 * f3, f1 * f4, 1);
 		// Render the object, using modelTutBox.renderAll();
-		int facing = waterWheel.getWorldObj().getBlockMetadata((int) waterWheel.xCoord, (int) waterWheel.yCoord, (int) waterWheel.zCoord);
+		int facing = CommonUtil.getBlockFacing(waterWheel.getWorldObj(), (int) waterWheel.xCoord, (int) waterWheel.yCoord, (int) waterWheel.zCoord);
 		if (facing == 3) {
 			GL11.glScalef(0.7f, 0.5f, 0.5f);
 			GL11.glScalef(1f, 0.36f, 0.36f);

--- a/src/main/java/train/client/render/models/blocks/ModelWindMill.java
+++ b/src/main/java/train/client/render/models/blocks/ModelWindMill.java
@@ -2,6 +2,7 @@ package train.client.render.models.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.AdvancedModelLoader;
@@ -44,7 +45,7 @@ public class ModelWindMill extends ModelBase {
 		float f4 = (float) (j & 255) / 255.0F;
 		GL11.glColor4f(f1 * f2, f1 * f3, f1 * f4, 1);
 		GL11.glScalef(0.5f, 0.5f, 0.5f);
-		int facing = windMill.getWorldObj().getBlockMetadata((int) windMill.xCoord, (int) windMill.yCoord, (int) windMill.zCoord);
+		int facing = CommonUtil.getBlockFacing(windMill.getWorldObj(), (int) windMill.xCoord, (int) windMill.yCoord, (int) windMill.zCoord);
 		if (facing == 3) {
 		}
 		if (facing == 1) {

--- a/src/main/java/train/client/render/models/blocks/ModelWindMillWheel.java
+++ b/src/main/java/train/client/render/models/blocks/ModelWindMillWheel.java
@@ -2,6 +2,7 @@ package train.client.render.models.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.AdvancedModelLoader;
@@ -45,7 +46,7 @@ public class ModelWindMillWheel extends ModelBase {
 		GL11.glColor4f(f1 * f2, f1 * f3, f1 * f4,1);
 		GL11.glScalef(0.45f, 0.45f, 0.45f);
 
-		int facing = windMill.getWorldObj().getBlockMetadata((int) windMill.xCoord, (int) windMill.yCoord, (int) windMill.zCoord);
+		int facing = CommonUtil.getBlockFacing(windMill.getWorldObj(), (int) windMill.xCoord, (int) windMill.yCoord, (int) windMill.zCoord);
 		if (facing == 3) {
 		}
 		if (facing == 1) {

--- a/src/main/java/train/common/api/AbstractControlCar.java
+++ b/src/main/java/train/common/api/AbstractControlCar.java
@@ -3,6 +3,7 @@ package train.common.api;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import cpw.mods.fml.client.FMLClientHandler;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.passive.EntityAnimal;
 import net.minecraft.entity.player.EntityPlayer;
@@ -199,7 +200,7 @@ public abstract class AbstractControlCar extends EntityRollingStock implements I
         {
             if (sounds.getEntityClass() != null && sounds.getEntityClass().equals(this.getClass()) && whistleDelay == 0)
             {
-                worldObj.playSoundAtEntity(this, Info.resourceLocation + ":" + sounds.getHornString(), sounds.getHornVolume(), 1.0F);
+                CommonUtil.playSound(this, Info.resourceLocation + ":" + sounds.getHornString(), sounds.getHornVolume(), 1.0F);
                 whistleDelay = 65;
             }
         }

--- a/src/main/java/train/common/api/DieselTrain.java
+++ b/src/main/java/train/common/api/DieselTrain.java
@@ -1,9 +1,9 @@
 package train.common.api;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
@@ -162,10 +162,10 @@ public abstract class DieselTrain extends Locomotive implements IFluidHandler {
 			motionZ *= 0.8;
 		} else if (ticksExisted%5==0 &&getTank().getFluidAmount()+100 < maxTank) {
 			FluidStack drain = null;
-			blocksToCheck = new TileEntity[]{worldObj.getTileEntity(MathHelper.floor_double(posX), MathHelper.floor_double(posY - 1), MathHelper.floor_double(posZ)),
-					worldObj.getTileEntity(MathHelper.floor_double(posX), MathHelper.floor_double(posY + 2), MathHelper.floor_double(posZ)),
-					worldObj.getTileEntity(MathHelper.floor_double(posX), MathHelper.floor_double(posY + 3), MathHelper.floor_double(posZ)),
-					worldObj.getTileEntity(MathHelper.floor_double(posX), MathHelper.floor_double(posY + 4), MathHelper.floor_double(posZ))
+			blocksToCheck = new TileEntity[]{worldObj.getTileEntity(CommonUtil.floorDouble(posX), CommonUtil.floorDouble(posY - 1), CommonUtil.floorDouble(posZ)),
+					worldObj.getTileEntity(CommonUtil.floorDouble(posX), CommonUtil.floorDouble(posY + 2), CommonUtil.floorDouble(posZ)),
+					worldObj.getTileEntity(CommonUtil.floorDouble(posX), CommonUtil.floorDouble(posY + 3), CommonUtil.floorDouble(posZ)),
+					worldObj.getTileEntity(CommonUtil.floorDouble(posX), CommonUtil.floorDouble(posY + 4), CommonUtil.floorDouble(posZ))
 			};
 
 			for (TileEntity block : blocksToCheck) {

--- a/src/main/java/train/common/api/ElectricTrain.java
+++ b/src/main/java/train/common/api/ElectricTrain.java
@@ -2,11 +2,11 @@ package train.common.api;
 
 import cofh.api.energy.IEnergyContainerItem;
 import cofh.api.energy.IEnergyHandler;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
@@ -62,7 +62,7 @@ public abstract class ElectricTrain extends Locomotive {
 
 			}else if (item instanceof IEnergyContainerItem)
 			{
-				int draw = MathHelper.floor_double(Math.min(200, maxEnergy - getFuel()) * 0.1); // amount of energy to attempt to draw this tick
+				int draw = CommonUtil.floorDouble(Math.min(200, maxEnergy - getFuel()) * 0.1); // amount of energy to attempt to draw this tick
 				fuelTrain += ((IEnergyContainerItem) item).extractEnergy(cargoItems[0], draw, false) * 10;
 			}
 			/*else if ((PluginIndustrialCraft.getItems().containsKey(PluginIndustrialCraft.getNames()[4]) && PluginIndustrialCraft.getItems().containsKey(PluginIndustrialCraft.getNames()[3])) && (item == PluginIndustrialCraft.getItems().get(PluginIndustrialCraft.getNames()[4]).getItem())) {
@@ -75,10 +75,10 @@ public abstract class ElectricTrain extends Locomotive {
 		  * 
 		  * if (locoInvent[u] != null) { if (locoInvent[u].itemID == PluginIndustrialCraft.getItems().get(PluginIndustrialCraft.getNames()[21]).itemID) { reduceExplosionChance += 10000; if (rand.nextInt(10) == 0 && (!worldObj.isRemote)) { locoInvent[u].setItemDamage(1); } } } } } else if ((locoInvent[0].itemID == PluginIndustrialCraft.getItems().get(PluginIndustrialCraft.getNames()[23]).itemID)) { hasUranium = true; fuelTrain = 800 + 1000000; // locoInvent[0] = null; if (!worldObj.isRemote) { decrStackSize(0, 1); } reduceExplosionChance = 1000; for (int u = 1; u < locoInvent.length; u++) {// checks the inventory if (locoInvent[u] != null) { if (locoInvent[u].itemID == PluginIndustrialCraft.getItems().get(PluginIndustrialCraft.getNames()[21]).itemID) { reduceExplosionChance += 10000; if (rand.nextInt(10) == 0 && (!worldObj.isRemote)) { locoInvent[u].setItemDamage(1); } } } } } } } */
 
-		blocksToCheck = new TileEntity[]{worldObj.getTileEntity(MathHelper.floor_double(posX), MathHelper.floor_double(posY-1),MathHelper.floor_double(posZ)),
-				worldObj.getTileEntity(MathHelper.floor_double(posX), MathHelper.floor_double(posY+2),MathHelper.floor_double(posZ)),
-				worldObj.getTileEntity(MathHelper.floor_double(posX), MathHelper.floor_double(posY+3),MathHelper.floor_double(posZ)),
-				worldObj.getTileEntity(MathHelper.floor_double(posX), MathHelper.floor_double(posY+4),MathHelper.floor_double(posZ))
+		blocksToCheck = new TileEntity[]{worldObj.getTileEntity(CommonUtil.floorDouble(posX), CommonUtil.floorDouble(posY-1),CommonUtil.floorDouble(posZ)),
+				worldObj.getTileEntity(CommonUtil.floorDouble(posX), CommonUtil.floorDouble(posY+2),CommonUtil.floorDouble(posZ)),
+				worldObj.getTileEntity(CommonUtil.floorDouble(posX), CommonUtil.floorDouble(posY+3),CommonUtil.floorDouble(posZ)),
+				worldObj.getTileEntity(CommonUtil.floorDouble(posX), CommonUtil.floorDouble(posY+4),CommonUtil.floorDouble(posZ))
 		};
 
 		int draw = 0;
@@ -90,7 +90,7 @@ public abstract class ElectricTrain extends Locomotive {
 					}
 					int max = ((IEnergyHandler) block).getEnergyStored(direction);
 					if (max > 0) {
-						draw = ((IEnergyHandler) block).receiveEnergy(direction, Math.max(-MathHelper.floor_double(Math.min(200, maxEnergy - getFuel()) * 0.1), -max), false);
+						draw = ((IEnergyHandler) block).receiveEnergy(direction, Math.max(-CommonUtil.floorDouble(Math.min(200, maxEnergy - getFuel()) * 0.1), -max), false);
 					}
 				}
 				fuelTrain += -draw;

--- a/src/main/java/train/common/api/EntityBogie.java
+++ b/src/main/java/train/common/api/EntityBogie.java
@@ -24,7 +24,6 @@ import net.minecraft.util.DamageSource;
 import net.minecraft.world.World;
 import train.common.blocks.BlockTCRail;
 import train.common.blocks.BlockTCRailGag;
-import train.common.core.util.TraincraftUtil;
 import train.common.items.TCRailTypes;
 import train.common.tile.TileTCRail;
 import train.common.tile.TileTCRailGag;

--- a/src/main/java/train/common/api/EntityRollingStock.java
+++ b/src/main/java/train/common/api/EntityRollingStock.java
@@ -67,7 +67,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static ebf.tim.utility.CommonUtil.radianF;
-import static train.common.core.util.TraincraftUtil.isRailBlockAt;
+import static ebf.tim.utility.CommonUtil.isRailBlockAt;
 
 public class EntityRollingStock extends AbstractTrains implements ILinkableCart {
     public int fuelTrain;

--- a/src/main/java/train/common/api/EntityRollingStock.java
+++ b/src/main/java/train/common/api/EntityRollingStock.java
@@ -818,17 +818,17 @@ public class EntityRollingStock extends AbstractTrains implements ILinkableCart 
         prevPosY = posY;
         prevPosZ = posZ;
 
-        int floor_posX = MathHelper.floor_double(posX);
-        int floor_posY = MathHelper.floor_double(posY);
-        int floor_posZ = MathHelper.floor_double(posZ);
+        int floor_posX = CommonUtil.floorDouble(posX);
+        int floor_posY = CommonUtil.floorDouble(posY);
+        int floor_posZ = CommonUtil.floorDouble(posZ);
 
         if (worldObj.isAirBlock(floor_posX, floor_posY, floor_posZ)) {
             floor_posY--;
-        } else if (isRailBlockAt(worldObj, floor_posX, floor_posY + 1, floor_posZ) || worldObj.getBlock(floor_posX, floor_posY + 1, floor_posZ) == BlockIDs.tcRail.block || worldObj.getBlock(floor_posX, floor_posY + 1, floor_posZ) == BlockIDs.tcRailGag.block) {
+        } else if (isRailBlockAt(worldObj, floor_posX, floor_posY + 1, floor_posZ) || CommonUtil.getBlockAt(worldObj, floor_posX, floor_posY + 1, floor_posZ) == BlockIDs.tcRail.block || CommonUtil.getBlockAt(worldObj, floor_posX, floor_posY + 1, floor_posZ) == BlockIDs.tcRailGag.block) {
             floor_posY++;
         }
 
-        l = worldObj.getBlock(floor_posX, floor_posY, floor_posZ);
+        l = CommonUtil.getBlockAt(worldObj, floor_posX, floor_posY, floor_posZ);
 
         updatePosition();
 

--- a/src/main/java/train/common/api/LiquidTank.java
+++ b/src/main/java/train/common/api/LiquidTank.java
@@ -1,12 +1,12 @@
 package train.common.api;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.DamageSource;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.*;
@@ -82,10 +82,10 @@ public class LiquidTank extends EntityRollingStock implements ISidedInventory {
 
         if (ticksExisted % 5 == 0 && fill(ForgeDirection.UNKNOWN, new FluidStack(FluidRegistry.WATER, 100), false) == 100) {
             FluidStack drain = null;
-            blocksToCheck = new TileEntity[]{worldObj.getTileEntity(MathHelper.floor_double(posX), MathHelper.floor_double(posY - 1), MathHelper.floor_double(posZ)),
-                    worldObj.getTileEntity(MathHelper.floor_double(posX), MathHelper.floor_double(posY + 2), MathHelper.floor_double(posZ)),
-                    worldObj.getTileEntity(MathHelper.floor_double(posX), MathHelper.floor_double(posY + 3), MathHelper.floor_double(posZ)),
-                    worldObj.getTileEntity(MathHelper.floor_double(posX), MathHelper.floor_double(posY + 4), MathHelper.floor_double(posZ))
+            blocksToCheck = new TileEntity[]{worldObj.getTileEntity(CommonUtil.floorDouble(posX), CommonUtil.floorDouble(posY - 1), CommonUtil.floorDouble(posZ)),
+                    worldObj.getTileEntity(CommonUtil.floorDouble(posX), CommonUtil.floorDouble(posY + 2), CommonUtil.floorDouble(posZ)),
+                    worldObj.getTileEntity(CommonUtil.floorDouble(posX), CommonUtil.floorDouble(posY + 3), CommonUtil.floorDouble(posZ)),
+                    worldObj.getTileEntity(CommonUtil.floorDouble(posX), CommonUtil.floorDouble(posY + 4), CommonUtil.floorDouble(posZ))
             };
 
             for (TileEntity block : blocksToCheck) {

--- a/src/main/java/train/common/api/Locomotive.java
+++ b/src/main/java/train/common/api/Locomotive.java
@@ -575,7 +575,7 @@ public abstract class Locomotive extends Freight implements WirelessTransmitter,
             soundHorn=getHorn();
         }
         if (soundHorn != null && !soundHorn.addr.isEmpty() && whistleDelay == 0) {
-            worldObj.playSoundAtEntity(this, soundHorn.addr, soundHorn.vol, soundHorn.pit);
+            CommonUtil.playSound(this, soundHorn.addr, soundHorn.vol, soundHorn.pit);
             whistleDelay = 65;
         }
 
@@ -596,7 +596,7 @@ public abstract class Locomotive extends Freight implements WirelessTransmitter,
             soundBell=getBell();
         }
         if (soundBell != null && !soundBell.addr.isEmpty() && whistleDelay == 0) {
-            worldObj.playSoundAtEntity(this, soundBell.addr, soundBell.vol, soundBell.pit);
+            CommonUtil.playSound(this, soundBell.addr, soundBell.vol, soundBell.pit);
             whistleDelay = 65;
         }
     }
@@ -688,7 +688,7 @@ public abstract class Locomotive extends Freight implements WirelessTransmitter,
                 if (getFuel() > 0 && this.isLocoTurnedOn()) {
                     double speed = Math.sqrt(motionX * motionX + motionZ * motionZ);
                     if (speed > -0.001D && speed < 0.01D && soundPosition == 0) {
-                        worldObj.playSoundAtEntity(this, soundIdle.addr, soundIdle.vol, soundIdle.pit);
+                        CommonUtil.playSound(this, soundIdle.addr, soundIdle.vol, soundIdle.pit);
                         soundPosition = soundIdle.len;
                     }
 
@@ -697,18 +697,18 @@ public abstract class Locomotive extends Freight implements WirelessTransmitter,
                     }
                     if (soundRunning!=null && soundRunning.runningPitch && !soundRunning.addr.isEmpty() && whistleDelay == 0) {
                         if (speed > 0.01D && speed < 0.06D && soundPosition == 0) {
-                            worldObj.playSoundAtEntity(this, soundRunning.addr, soundRunning.vol, soundRunning.pit-0.3f);
+                            CommonUtil.playSound(this, soundRunning.addr, soundRunning.vol, soundRunning.pit-0.3f);
                             soundPosition = soundRunning.len;
                         } else if (speed > 0.06D && speed < 0.2D && soundPosition == 0) {
-                            worldObj.playSoundAtEntity(this, soundRunning.addr, soundRunning.vol, soundRunning.pit-0.1f);
+                            CommonUtil.playSound(this, soundRunning.addr, soundRunning.vol, soundRunning.pit-0.1f);
                             soundPosition = soundRunning.len / 2;
                         } else if (speed > 0.2D && soundPosition == 0) {
-                            worldObj.playSoundAtEntity(this, soundRunning.addr, soundRunning.vol, soundRunning.pit);
+                            CommonUtil.playSound(this, soundRunning.addr, soundRunning.vol, soundRunning.pit);
                             soundPosition = soundRunning.len / 3;
                         }
                     } else {
                         if (speed > 0.01D && soundPosition == 0) {
-                            worldObj.playSoundAtEntity(this, soundRunning.addr, soundRunning.vol, soundRunning.pit);
+                            CommonUtil.playSound(this, soundRunning.addr, soundRunning.vol, soundRunning.pit);
                             soundPosition = soundRunning.len;
                         }
                     }

--- a/src/main/java/train/common/api/SteamTrain.java
+++ b/src/main/java/train/common/api/SteamTrain.java
@@ -1,9 +1,9 @@
 package train.common.api;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.*;
@@ -171,10 +171,10 @@ public abstract class SteamTrain extends Locomotive implements IFluidHandler {
 			FluidStack drain = null;
 
 			if(fill(ForgeDirection.UNKNOWN,new FluidStack(FluidRegistry.WATER, 100), false)==100) {
-				blocksToCheck = new TileEntity[]{worldObj.getTileEntity(MathHelper.floor_double(posX), MathHelper.floor_double(posY - 1), MathHelper.floor_double(posZ)),
-						worldObj.getTileEntity(MathHelper.floor_double(posX), MathHelper.floor_double(posY + 2), MathHelper.floor_double(posZ)),
-						worldObj.getTileEntity(MathHelper.floor_double(posX), MathHelper.floor_double(posY + 3), MathHelper.floor_double(posZ)),
-						worldObj.getTileEntity(MathHelper.floor_double(posX), MathHelper.floor_double(posY + 4), MathHelper.floor_double(posZ))
+				blocksToCheck = new TileEntity[]{worldObj.getTileEntity(CommonUtil.floorDouble(posX), CommonUtil.floorDouble(posY - 1), CommonUtil.floorDouble(posZ)),
+						worldObj.getTileEntity(CommonUtil.floorDouble(posX), CommonUtil.floorDouble(posY + 2), CommonUtil.floorDouble(posZ)),
+						worldObj.getTileEntity(CommonUtil.floorDouble(posX), CommonUtil.floorDouble(posY + 3), CommonUtil.floorDouble(posZ)),
+						worldObj.getTileEntity(CommonUtil.floorDouble(posX), CommonUtil.floorDouble(posY + 4), CommonUtil.floorDouble(posZ))
 				};
 
 				for (TileEntity block : blocksToCheck) {

--- a/src/main/java/train/common/api/Tender.java
+++ b/src/main/java/train/common/api/Tender.java
@@ -1,9 +1,9 @@
 package train.common.api;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.*;
@@ -171,10 +171,10 @@ public abstract class Tender extends Freight implements IFluidHandler {
 
         if (ticksExisted % 5 == 0 && fill(ForgeDirection.UNKNOWN, new FluidStack(FluidRegistry.WATER, 100), false) == 100) {
             FluidStack drain = null;
-            blocksToCheck = new TileEntity[]{worldObj.getTileEntity(MathHelper.floor_double(posX), MathHelper.floor_double(posY - 1), MathHelper.floor_double(posZ)),
-                    worldObj.getTileEntity(MathHelper.floor_double(posX), MathHelper.floor_double(posY + 2), MathHelper.floor_double(posZ)),
-                    worldObj.getTileEntity(MathHelper.floor_double(posX), MathHelper.floor_double(posY + 3), MathHelper.floor_double(posZ)),
-                    worldObj.getTileEntity(MathHelper.floor_double(posX), MathHelper.floor_double(posY + 4), MathHelper.floor_double(posZ))
+            blocksToCheck = new TileEntity[]{worldObj.getTileEntity(CommonUtil.floorDouble(posX), CommonUtil.floorDouble(posY - 1), CommonUtil.floorDouble(posZ)),
+                    worldObj.getTileEntity(CommonUtil.floorDouble(posX), CommonUtil.floorDouble(posY + 2), CommonUtil.floorDouble(posZ)),
+                    worldObj.getTileEntity(CommonUtil.floorDouble(posX), CommonUtil.floorDouble(posY + 3), CommonUtil.floorDouble(posZ)),
+                    worldObj.getTileEntity(CommonUtil.floorDouble(posX), CommonUtil.floorDouble(posY + 4), CommonUtil.floorDouble(posZ))
             };
 
             for (TileEntity block : blocksToCheck) {

--- a/src/main/java/train/common/api/TrainsSignal.java
+++ b/src/main/java/train/common/api/TrainsSignal.java
@@ -1,5 +1,6 @@
 package train.common.api;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.world.World;
 import train.common.library.BlockIDs;
 
@@ -18,7 +19,7 @@ public class TrainsSignal {
 
         if ((motionX > 0) && motionZ == 0) {
             for (int t = 0; t < 12; t++) {
-                if ((worldObj.getBlock(i + t, j, k + l) == BlockIDs.signal.block) || (worldObj.getBlock(i + t, j, k - l) == BlockIDs.signal.block)) {// k = sides, j= heigh, i front
+                if ((CommonUtil.getBlockAt(worldObj, i + t, j, k + l) == BlockIDs.signal.block) || (CommonUtil.getBlockAt(worldObj, i + t, j, k - l) == BlockIDs.signal.block)) {// k = sides, j= heigh, i front
                     action = 1;
                     if (t == 2) {
                         action = 2;
@@ -31,7 +32,7 @@ public class TrainsSignal {
             /* North */
         } else if ((motionX < 0) && motionZ == 0) {
             for (int t = 0; t < 12; t++) {
-                if ((worldObj.getBlock(i - t, j, k + l) == BlockIDs.signal.block) || (worldObj.getBlock(i - t, j, k - l) == BlockIDs.signal.block)) {// k = sides, j= heigh, i front
+                if ((CommonUtil.getBlockAt(worldObj, i - t, j, k + l) == BlockIDs.signal.block) || (CommonUtil.getBlockAt(worldObj, i - t, j, k - l) == BlockIDs.signal.block)) {// k = sides, j= heigh, i front
                     action = 1;
                     if (t == 2) {
                         action = 2;
@@ -45,7 +46,7 @@ public class TrainsSignal {
         } else if ((motionZ > 0) && motionX == 0) {
             // k - = front
             for (int t = 0; t < 12; t++) {
-                if ((worldObj.getBlock(i + l, j, k + t) == BlockIDs.signal.block) || (worldObj.getBlock(i - l, j, k + t) == BlockIDs.signal.block)) {// k = sides, j= heigh, i front
+                if ((CommonUtil.getBlockAt(worldObj, i + l, j, k + t) == BlockIDs.signal.block) || (CommonUtil.getBlockAt(worldObj, i - l, j, k + t) == BlockIDs.signal.block)) {// k = sides, j= heigh, i front
                     action = 1;
                     if (t == 2) {
                         action = 2;
@@ -58,7 +59,7 @@ public class TrainsSignal {
             /* WEST */
         } else if ((motionZ < 0) && motionX == 0) {
             for (int t = 0; t < 12; t++) {
-                if ((worldObj.getBlock(i + l, j, k - t) == BlockIDs.signal.block) || (worldObj.getBlock(i - l, j, k - t) == BlockIDs.signal.block)) {// k = sides, j= heigh, i front
+                if ((CommonUtil.getBlockAt(worldObj, i + l, j, k - t) == BlockIDs.signal.block) || (CommonUtil.getBlockAt(worldObj, i - l, j, k - t) == BlockIDs.signal.block)) {// k = sides, j= heigh, i front
                     action = 1;
                     if (t == 2) {
                         action = 2;

--- a/src/main/java/train/common/blocks/BlockAmericanStopper.java
+++ b/src/main/java/train/common/blocks/BlockAmericanStopper.java
@@ -9,6 +9,7 @@ package train.common.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -16,7 +17,6 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import train.common.Traincraft;
 import train.common.library.Info;
@@ -61,8 +61,8 @@ public class BlockAmericanStopper extends BlockContainer {
     @Override
     public void onBlockPlacedBy(World world, int par2, int par3, int par4, EntityLivingBase living, ItemStack stack) {
         TileAmericanStopper te = (TileAmericanStopper) world.getTileEntity(par2, par3, par4);
-        int var6 = MathHelper.floor_double(living.rotationYaw * 4.0F / 360.0F + 0.5D) & 3;
-        int var7 = world.getBlockMetadata(par2, par3, par4) >> 2;
+        int var6 = CommonUtil.floorDouble(living.rotationYaw * 4.0F / 360.0F + 0.5D) & 3;
+        int var7 = CommonUtil.getBlockFacing(world, par2, par3, par4) >> 2;
         ++var6;
         var6 %= 4;
 

--- a/src/main/java/train/common/blocks/BlockAssemblyTableI.java
+++ b/src/main/java/train/common/blocks/BlockAssemblyTableI.java
@@ -1,5 +1,6 @@
 package train.common.blocks;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.EntityLivingBase;
@@ -7,7 +8,6 @@ import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import train.common.Traincraft;
@@ -89,7 +89,7 @@ public class BlockAssemblyTableI extends BlockDynamic {
 	@Override
 	public void onBlockAdded(World world, int i, int j, int k) {
 		super.onBlockAdded(world, i, j, k);
-		world.markBlockForUpdate(i, j, k);
+		CommonUtil.markBlockForUpdate(world, i, j, k);
 	}
 
 	@Override
@@ -97,9 +97,9 @@ public class BlockAssemblyTableI extends BlockDynamic {
 		super.onBlockPlacedBy(world, i, j, k, entityliving, stack);
 		TileCrafterTierI te = (TileCrafterTierI) world.getTileEntity(i, j, k);
 		if (te != null) {
-			int dir = MathHelper.floor_double((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
+			int dir = CommonUtil.floorDouble((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
 			te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
-			world.markBlockForUpdate(i, j, k);
+			CommonUtil.markBlockForUpdate(world, i, j, k);
 		}
 	}
 

--- a/src/main/java/train/common/blocks/BlockAssemblyTableII.java
+++ b/src/main/java/train/common/blocks/BlockAssemblyTableII.java
@@ -1,5 +1,6 @@
 package train.common.blocks;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.EntityLivingBase;
@@ -7,7 +8,6 @@ import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import train.common.Traincraft;
@@ -86,7 +86,7 @@ public class BlockAssemblyTableII extends BlockDynamic {
 	@Override
 	public void onBlockAdded(World world, int i, int j, int k) {
 		super.onBlockAdded(world, i, j, k);
-		world.markBlockForUpdate(i, j, k);
+		CommonUtil.markBlockForUpdate(world, i, j, k);
 	}
 
 	@Override
@@ -94,9 +94,9 @@ public class BlockAssemblyTableII extends BlockDynamic {
 		super.onBlockPlacedBy(world, i, j, k, entityliving, stack);
 		TileCrafterTierII te = (TileCrafterTierII) world.getTileEntity(i, j, k);
 		if (te != null) {
-			int dir = MathHelper.floor_double((entityliving.rotationYaw * 4F) / 360F + 0.5D) & 3;
+			int dir = CommonUtil.floorDouble((entityliving.rotationYaw * 4F) / 360F + 0.5D) & 3;
 			te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
-			world.markBlockForUpdate(i, j, k);
+			CommonUtil.markBlockForUpdate(world, i, j, k);
 		}
 	}
 

--- a/src/main/java/train/common/blocks/BlockAssemblyTableIII.java
+++ b/src/main/java/train/common/blocks/BlockAssemblyTableIII.java
@@ -1,5 +1,6 @@
 package train.common.blocks;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.EntityLivingBase;
@@ -7,7 +8,6 @@ import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import train.common.Traincraft;
@@ -87,16 +87,16 @@ public class BlockAssemblyTableIII extends BlockDynamic {
 	@Override
 	public void onBlockAdded(World world, int i, int j, int k) {
 		super.onBlockAdded(world, i, j, k);
-		world.markBlockForUpdate(i, j, k);
+		CommonUtil.markBlockForUpdate(world, i, j, k);
 	}
 
 	@Override
 	public void onBlockPlacedBy(World world, int i, int j, int k, EntityLivingBase entityliving, ItemStack stack) {
 		TileCrafterTierIII te = (TileCrafterTierIII) world.getTileEntity(i, j, k);
 		if (te != null) {
-			int dir = MathHelper.floor_double((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
+			int dir = CommonUtil.floorDouble((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
 			te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
-			world.markBlockForUpdate(i, j, k);
+			CommonUtil.markBlockForUpdate(world, i, j, k);
 		}
 	}
 

--- a/src/main/java/train/common/blocks/BlockDistil.java
+++ b/src/main/java/train/common/blocks/BlockDistil.java
@@ -12,7 +12,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -90,7 +89,7 @@ public class BlockDistil extends BlockDynamic {
 	}
 
 	public static void updateDistilBlockState(boolean flag, World world, int i, int j, int k) {
-		int l = world.getBlockMetadata(i, j, k);
+		int l = CommonUtil.getBlockFacing(world, i, j, k);
 		TileEntity tileentity = world.getTileEntity(i, j, k);
 		keepDistilInventory = true;
 		if (flag) {
@@ -145,16 +144,16 @@ public class BlockDistil extends BlockDynamic {
 	@Override
 	public void onBlockAdded(World world, int i, int j, int k) {
 		super.onBlockAdded(world, i, j, k);
-		world.markBlockForUpdate(i, j, k);
+		CommonUtil.markBlockForUpdate(world, i, j, k);
 	}
 
 	@Override
 	public void onBlockPlacedBy(World world, int i, int j, int k, EntityLivingBase entityliving, ItemStack stack) {
 		TileEntityDistil te = (TileEntityDistil) world.getTileEntity(i, j, k);
 		if (te != null) {
-			int dir = MathHelper.floor_double((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
+			int dir = CommonUtil.floorDouble((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
 			te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
-			world.markBlockForUpdate(i, j, k);
+			CommonUtil.markBlockForUpdate(world, i, j, k);
 		}
 	}
 

--- a/src/main/java/train/common/blocks/BlockEmbeddedStopper.java
+++ b/src/main/java/train/common/blocks/BlockEmbeddedStopper.java
@@ -9,6 +9,7 @@ package train.common.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -16,7 +17,6 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import train.common.Traincraft;
 import train.common.library.Info;
@@ -61,8 +61,8 @@ public class BlockEmbeddedStopper extends BlockContainer {
     @Override
     public void onBlockPlacedBy(World world, int par2, int par3, int par4, EntityLivingBase living, ItemStack stack) {
         TileEmbeddedStopper te = (TileEmbeddedStopper) world.getTileEntity(par2, par3, par4);
-        int var6 = MathHelper.floor_double(living.rotationYaw * 4.0F / 360.0F + 0.5D) & 3;
-        int var7 = world.getBlockMetadata(par2, par3, par4) >> 2;
+        int var6 = CommonUtil.floorDouble(living.rotationYaw * 4.0F / 360.0F + 0.5D) & 3;
+        int var7 = CommonUtil.getBlockFacing(world, par2, par3, par4) >> 2;
         ++var6;
         var6 %= 4;
 

--- a/src/main/java/train/common/blocks/BlockGeneratorDiesel.java
+++ b/src/main/java/train/common/blocks/BlockGeneratorDiesel.java
@@ -99,28 +99,28 @@ public class BlockGeneratorDiesel extends BlockContainer {
 		if (var6 == 0) {
 			if (te != null) {
 				te.setFacing(2 | var7 << 2);
-				 world.setBlockMetadataWithNotify(par2, par3, par4, 2 | var7 << 2, 2);
+				 CommonUtil.setBlockMeta(world, par2, par3, par4, 2 | var7 << 2);
 			}
 		}
 
 		if (var6 == 1) {
 			if (te != null) {
 				te.setFacing(3 | var7 << 2);
-				world.setBlockMetadataWithNotify(par2, par3, par4, 3 | var7 << 2, 2);
+				CommonUtil.setBlockMeta(world, par2, par3, par4, 3 | var7 << 2);
 			}
 		}
 
 		if (var6 == 2) {
 			if (te != null) {
 				te.setFacing(0 | var7 << 2);
-				world.setBlockMetadataWithNotify(par2, par3, par4, 0 | var7 << 2, 2);
+				CommonUtil.setBlockMeta(world, par2, par3, par4, 0 | var7 << 2);
 			}
 		}
 
 		if (var6 == 3) {
 			if (te != null) {
 				te.setFacing(1 | var7 << 2);
-				world.setBlockMetadataWithNotify(par2, par3, par4, 1 | var7 << 2, 2);
+				CommonUtil.setBlockMeta(world, par2, par3, par4, 1 | var7 << 2);
 			}
 		}
 

--- a/src/main/java/train/common/blocks/BlockGeneratorDiesel.java
+++ b/src/main/java/train/common/blocks/BlockGeneratorDiesel.java
@@ -10,6 +10,7 @@ package train.common.blocks;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
@@ -19,7 +20,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import train.common.Traincraft;
 import train.common.library.GuiIDs;
@@ -91,8 +91,8 @@ public class BlockGeneratorDiesel extends BlockContainer {
 	@Override
 	public void onBlockPlacedBy(World world, int par2, int par3, int par4, EntityLivingBase living, ItemStack stack) {
 		TileGeneratorDiesel te = (TileGeneratorDiesel) world.getTileEntity(par2, par3, par4);
-		int var6 = MathHelper.floor_double((double) (living.rotationYaw * 4.0F / 360.0F) + 0.5D) & 3;
-		int var7 = world.getBlockMetadata(par2, par3, par4);
+		int var6 = CommonUtil.floorDouble((double) (living.rotationYaw * 4.0F / 360.0F) + 0.5D) & 3;
+		int var7 = CommonUtil.getBlockFacing(world, par2, par3, par4);
 		++var6;
 		var6 %= 4;
 
@@ -129,7 +129,7 @@ public class BlockGeneratorDiesel extends BlockContainer {
 	@SideOnly(Side.CLIENT)
 	@Override
 	public void randomDisplayTick(World world, int par2, int par3, int par4, Random rand) {
-		int l = world.getBlockMetadata(par2, par3, par4);
+		int l = CommonUtil.getBlockFacing(world, par2, par3, par4);
 		TileEntity tile = world.getTileEntity(par2, par3, par4);
 		if(tile !=null && tile instanceof TileGeneratorDiesel && ((TileGeneratorDiesel)tile).currentBurnTime > 0){
 			double d0 = (double) ((float) par2 + 0.5F);

--- a/src/main/java/train/common/blocks/BlockMFPBWigWag.java
+++ b/src/main/java/train/common/blocks/BlockMFPBWigWag.java
@@ -1,10 +1,10 @@
 package train.common.blocks;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import train.common.Traincraft;
@@ -63,9 +63,9 @@ public class BlockMFPBWigWag extends BlockSignal {
 			te = (TileMFPBWigWag) world.getTileEntity(i, j, k);
 		}
 		if (te != null) {
-			int dir = MathHelper.floor_double((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
+			int dir = CommonUtil.floorDouble((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
 			te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
-			world.markBlockForUpdate(i, j, k);
+			CommonUtil.markBlockForUpdate(world, i, j, k);
 		}
 	}
 }

--- a/src/main/java/train/common/blocks/BlockMetroMadridPole.java
+++ b/src/main/java/train/common/blocks/BlockMetroMadridPole.java
@@ -1,5 +1,6 @@
 package train.common.blocks;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
@@ -9,7 +10,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.IIcon;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import train.common.Traincraft;
@@ -31,7 +31,7 @@ public class BlockMetroMadridPole extends Block implements ITileEntityProvider {
     @Override
     public void onBlockPlacedBy(World world, int par2, int par3, int par4, EntityLivingBase living, ItemStack stack) {
         TileMetroMadridPole te = (TileMetroMadridPole) world.getTileEntity(par2, par3, par4);
-        int dir = MathHelper.floor_double((double) ((living.rotationYaw * 4F) / 360F) + 0.5D) & 3;
+        int dir = CommonUtil.floorDouble((double) ((living.rotationYaw * 4F) / 360F) + 0.5D) & 3;
         te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
     }
 

--- a/src/main/java/train/common/blocks/BlockOpenHearthFurnace.java
+++ b/src/main/java/train/common/blocks/BlockOpenHearthFurnace.java
@@ -19,7 +19,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -50,7 +49,7 @@ public class BlockOpenHearthFurnace extends BlockDynamic {
 
 
 	public static void updateHearthFurnaceBlockState(boolean flag, World world, int i, int j, int k, Random random) {
-		int l = world.getBlockMetadata(i, j, k);
+		int l = CommonUtil.getBlockFacing(world, i, j, k);
 		TileEntity tileentity = world.getTileEntity(i, j, k);
 
 		keepFurnaceInventory = true;
@@ -86,7 +85,7 @@ public class BlockOpenHearthFurnace extends BlockDynamic {
 	@Override
 	public void onBlockAdded(World world, int i, int j, int k) {
 		super.onBlockAdded(world, i, j, k);
-		world.markBlockForUpdate(i, j, k);
+		CommonUtil.markBlockForUpdate(world, i, j, k);
 	}
 
 	@Override
@@ -128,9 +127,9 @@ public class BlockOpenHearthFurnace extends BlockDynamic {
 	public void onBlockPlacedBy(World world, int i, int j, int k, EntityLivingBase entityliving, ItemStack stack) {
 		TileEntityOpenHearthFurnace te = (TileEntityOpenHearthFurnace) world.getTileEntity(i, j, k);
 		if (te != null) {
-			int dir = MathHelper.floor_double((entityliving.rotationYaw * 4F) / 360F + 0.5D) & 3;
+			int dir = CommonUtil.floorDouble((entityliving.rotationYaw * 4F) / 360F + 0.5D) & 3;
 			te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
-			world.markBlockForUpdate(i, j, k);
+			CommonUtil.markBlockForUpdate(world, i, j, k);
 		}
 	}
 

--- a/src/main/java/train/common/blocks/BlockOreTC.java
+++ b/src/main/java/train/common/blocks/BlockOreTC.java
@@ -2,6 +2,7 @@ package train.common.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockFalling;
 import net.minecraft.block.material.Material;
@@ -49,12 +50,12 @@ public class BlockOreTC extends BlockFalling {
 
 	@Override
     public void onBlockAdded(World world, int x, int y, int z) {
-		if (world.getBlockMetadata(x, y, z) == 1) world.scheduleBlockUpdate(x, y, z, this, this.tickRate(world));
+		if (CommonUtil.getBlockFacing(world, x, y, z) == 1) world.scheduleBlockUpdate(x, y, z, this, this.tickRate(world));
     }
 
 	@Override
     public void onNeighborBlockChange(World world, int x, int y, int z, Block block) {
-		if (world.getBlockMetadata(x, y, z) == 1) world.scheduleBlockUpdate(x, y, z, this, this.tickRate(world));
+		if (CommonUtil.getBlockFacing(world, x, y, z) == 1) world.scheduleBlockUpdate(x, y, z, this, this.tickRate(world));
     }
 
 	@Override

--- a/src/main/java/train/common/blocks/BlockSignal.java
+++ b/src/main/java/train/common/blocks/BlockSignal.java
@@ -1,6 +1,7 @@
 package train.common.blocks;
 
 import cpw.mods.fml.client.registry.RenderingRegistry;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
@@ -10,7 +11,6 @@ import net.minecraft.item.Item;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.IIcon;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import train.common.Traincraft;
 import train.common.library.ItemIDs;
@@ -80,8 +80,8 @@ public class BlockSignal extends BlockContainer {
 
 		/*
 		 * if (l == 0) { world.setBlockMetadataWithNotify(i, j, k, 2); te.rot = 2; } if (l == 1) { world.setBlockMetadataWithNotify(i, j, k, 5); te.rot = 5; } if (l == 2) { world.setBlockMetadataWithNotify(i, j, k, 3); te.rot = 3; } if (l == 3) { world.setBlockMetadataWithNotify(i, j, k, 4); te.rot = 4; } */
-		int var6 = MathHelper.floor_double((double) (entityliving.rotationYaw * 4.0F / 360.0F) + 0.5D) & 3;
-		int var7 = world.getBlockMetadata(i, j, k) >> 2;
+		int var6 = CommonUtil.floorDouble((double) (entityliving.rotationYaw * 4.0F / 360.0F) + 0.5D) & 3;
+		int var7 = CommonUtil.getBlockFacing(world, i, j, k) >> 2;
 		++var6;
 		var6 %= 4;
 

--- a/src/main/java/train/common/blocks/BlockStopper.java
+++ b/src/main/java/train/common/blocks/BlockStopper.java
@@ -9,6 +9,7 @@ package train.common.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -16,7 +17,6 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import train.common.Traincraft;
 import train.common.library.Info;
@@ -61,8 +61,8 @@ public class BlockStopper extends BlockContainer {
 	@Override
 	public void onBlockPlacedBy(World world, int par2, int par3, int par4, EntityLivingBase living, ItemStack stack) {
 		TileStopper te = (TileStopper) world.getTileEntity(par2, par3, par4);
-		int var6 = MathHelper.floor_double(living.rotationYaw * 4.0F / 360.0F + 0.5D) & 3;
-		int var7 = world.getBlockMetadata(par2, par3, par4) >> 2;
+		int var6 = CommonUtil.floorDouble(living.rotationYaw * 4.0F / 360.0F + 0.5D) & 3;
+		int var7 = CommonUtil.getBlockFacing(world, par2, par3, par4) >> 2;
 		++var6;
 		var6 %= 4;
 

--- a/src/main/java/train/common/blocks/BlockTCRail.java
+++ b/src/main/java/train/common/blocks/BlockTCRail.java
@@ -167,7 +167,7 @@ public class BlockTCRail extends Block {
 				l++;
 				if (l > 3)
 					l = 0;
-				world.setBlockMetadataWithNotify(i, j, k, l, 2);
+				CommonUtil.setBlockMeta(world, i, j, k, l);
 				return true;
 			}
 			//((TileTCRail)te).printInfo();

--- a/src/main/java/train/common/blocks/BlockTCRail.java
+++ b/src/main/java/train/common/blocks/BlockTCRail.java
@@ -98,19 +98,19 @@ public class BlockTCRail extends Block {
 		for(int x : matrixXZ){
 			for(int z : matrixXZ){
 				for(int y : matrixY){
-					if (tileEntity != null && world.getBlock(x + tileEntity.xCoord, y + tileEntity.yCoord, z + tileEntity.zCoord)instanceof BlockTCRailGag){
+					if (tileEntity != null && CommonUtil.getBlockAt(world, x + tileEntity.xCoord, y + tileEntity.yCoord, z + tileEntity.zCoord)instanceof BlockTCRailGag){
 						if(((TileTCRailGag)world.getTileEntity(x + tileEntity.xCoord, y + tileEntity.yCoord, z + tileEntity.zCoord)).originX.size()>1){
 							((TileTCRailGag)world.getTileEntity(x + tileEntity.xCoord, y + tileEntity.yCoord, z + tileEntity.zCoord)).originX.removeAll(Arrays.asList(new int[]{tileEntity.xCoord}));
 							((TileTCRailGag)world.getTileEntity(x + tileEntity.xCoord, y + tileEntity.yCoord, z + tileEntity.zCoord)).originY.removeAll(Arrays.asList(new int[]{tileEntity.yCoord}));
 							((TileTCRailGag)world.getTileEntity(x + tileEntity.xCoord, y + tileEntity.yCoord, z + tileEntity.zCoord)).originY.removeAll(Arrays.asList(new int[]{tileEntity.zCoord}));
 						} else {
 							world.notifyBlockChange((x + tileEntity.xCoord), (y + tileEntity.yCoord + 1), (z + tileEntity.zCoord), Blocks.air);
-							world.markBlockForUpdate((x + tileEntity.xCoord), (y + tileEntity.yCoord + 1), (z + tileEntity.zCoord));
+							CommonUtil.markBlockForUpdate(world, (x + tileEntity.xCoord), (y + tileEntity.yCoord + 1), (z + tileEntity.zCoord));
 						}
 					}
-					if (tileEntity != null && world.getBlock(x + tileEntity.xCoord, y + tileEntity.yCoord, z + tileEntity.zCoord)instanceof BlockTCRail){
+					if (tileEntity != null && CommonUtil.getBlockAt(world, x + tileEntity.xCoord, y + tileEntity.yCoord, z + tileEntity.zCoord)instanceof BlockTCRail){
 						world.notifyBlockChange((x  + tileEntity.xCoord), (y + tileEntity.yCoord + 1), (z  + tileEntity.zCoord), Blocks.air);
-						world.markBlockForUpdate((x  + tileEntity.xCoord), (y + tileEntity.yCoord + 1 ), (z  + tileEntity.zCoord));
+						CommonUtil.markBlockForUpdate(world, (x  + tileEntity.xCoord), (y + tileEntity.yCoord + 1 ), (z  + tileEntity.zCoord));
 					}
 				}
 			}
@@ -130,7 +130,7 @@ public class BlockTCRail extends Block {
                     world.func_147480_a(i, j, k, false);
                 }
             }
-            if (!World.doesBlockHaveSolidTopSurface(world, i, j - 1, k) && world.getBlock(i, j - 1, k) != TCBlocks.bridgePillar) {
+            if (!World.doesBlockHaveSolidTopSurface(world, i, j - 1, k) && CommonUtil.getBlockAt(world, i, j - 1, k) != TCBlocks.bridgePillar) {
                 // NOTE: func_147480_a = destroyBlock
                 world.func_147480_a(i, j, k, false);
                 world.removeTileEntity(i, j, k);
@@ -161,7 +161,7 @@ public class BlockTCRail extends Block {
 	@Override
 	public boolean onBlockActivated(World world, int i, int j, int k, EntityPlayer player, int par6, float par7, float par8, float par9) {
 		TileEntity te = world.getTileEntity(i, j, k);
-		int l = world.getBlockMetadata(i, j, k);
+		int l = CommonUtil.getBlockFacing(world, i, j, k);
 		if (!world.isRemote && te != null && (te instanceof TileTCRail)) {
 			if (player != null && player.inventory != null && player.inventory.getCurrentItem() != null && (player.inventory.getCurrentItem().getItem() instanceof ItemWrench) && ((TileTCRail) te).getType() != null && ((TileTCRail) te).getType().equals( EnumTracks.SMALL_STRAIGHT.getLabel())) {
 				l++;

--- a/src/main/java/train/common/blocks/BlockTCRailGag.java
+++ b/src/main/java/train/common/blocks/BlockTCRailGag.java
@@ -2,6 +2,7 @@ package train.common.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -48,13 +49,13 @@ public class BlockTCRailGag extends Block {
 			for(int x : matrixXZ){
 				for(int z : matrixXZ){
 					for(int y : matrixY){
-						if (world.getBlock(x + tileEntity.xCoord, y + tileEntity.yCoord, z + tileEntity.zCoord)instanceof BlockTCRailGag){
+						if (CommonUtil.getBlockAt(world, x + tileEntity.xCoord, y + tileEntity.yCoord, z + tileEntity.zCoord)instanceof BlockTCRailGag){
 							world.notifyBlockChange((x  + tileEntity.xCoord), (y + tileEntity.yCoord + 1), (z  + tileEntity.zCoord), Blocks.air);
-							world.markBlockForUpdate((x  + tileEntity.xCoord), (y + tileEntity.yCoord + 1 ), (z  + tileEntity.zCoord));
+							CommonUtil.markBlockForUpdate(world, (x  + tileEntity.xCoord), (y + tileEntity.yCoord + 1 ), (z  + tileEntity.zCoord));
 						}
-						if (world.getBlock(x + tileEntity.xCoord, y + tileEntity.yCoord, z + tileEntity.zCoord)instanceof BlockTCRail){
+						if (CommonUtil.getBlockAt(world, x + tileEntity.xCoord, y + tileEntity.yCoord, z + tileEntity.zCoord)instanceof BlockTCRail){
 							world.notifyBlockChange((x  + tileEntity.xCoord), (y + tileEntity.yCoord + 1), (z  + tileEntity.zCoord), Blocks.air);
-							world.markBlockForUpdate((x  + tileEntity.xCoord), (y + tileEntity.yCoord + 1 ), (z  + tileEntity.zCoord));
+							CommonUtil.markBlockForUpdate(world, (x  + tileEntity.xCoord), (y + tileEntity.yCoord + 1 ), (z  + tileEntity.zCoord));
 						}
 					}
 				}
@@ -106,7 +107,7 @@ public class BlockTCRailGag extends Block {
 				world.func_147480_a(i, j, k, false);
 				world.removeTileEntity(i, j, k);
 			}
-			if (!World.doesBlockHaveSolidTopSurface(world, i, j - 1, k) && world.getBlock(i, j-1, k) != TCBlocks.bridgePillar) {
+			if (!World.doesBlockHaveSolidTopSurface(world, i, j - 1, k) && CommonUtil.getBlockAt(world, i, j-1, k) != TCBlocks.bridgePillar) {
 				// NOTE: func_147480_a = destroyBlock
 				world.func_147480_a(i, j, k, false);
 				world.removeTileEntity(i, j, k);

--- a/src/main/java/train/common/blocks/BlockTrainWorkbench.java
+++ b/src/main/java/train/common/blocks/BlockTrainWorkbench.java
@@ -1,5 +1,6 @@
 package train.common.blocks;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.EntityLivingBase;
@@ -7,7 +8,6 @@ import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import train.common.Traincraft;
@@ -78,16 +78,16 @@ public class BlockTrainWorkbench extends BlockDynamic {
 	@Override
 	public void onBlockAdded(World world, int i, int j, int k) {
 		super.onBlockAdded(world, i, j, k);
-		world.markBlockForUpdate(i, j, k);
+		CommonUtil.markBlockForUpdate(world, i, j, k);
 	}
 
 	@Override
 	public void onBlockPlacedBy(World world, int i, int j, int k, EntityLivingBase entityliving, ItemStack stack) {
 		TileTrainWbench te = (TileTrainWbench) world.getTileEntity(i, j, k);
 		if (te != null) {
-			int dir = MathHelper.floor_double((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
+			int dir = CommonUtil.floorDouble((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
 			te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
-			world.markBlockForUpdate(i, j, k);
+			CommonUtil.markBlockForUpdate(world, i, j, k);
 		}
 	}
 

--- a/src/main/java/train/common/blocks/BlockTraincraftFluid.java
+++ b/src/main/java/train/common/blocks/BlockTraincraftFluid.java
@@ -2,6 +2,7 @@ package train.common.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.util.IIcon;
@@ -77,7 +78,7 @@ public class BlockTraincraftFluid extends BlockFluidClassic {
 	
 	@Override
 	public boolean displaceIfPossible(World world, int x, int y, int z) {
-		return (!world.getBlock(x,  y,  z).getMaterial().isLiquid() && super.displaceIfPossible(world, x, y, z));
+		return (!CommonUtil.getBlockAt(world, x,  y,  z).getMaterial().isLiquid() && super.displaceIfPossible(world, x, y, z));
 	}
 	
 	@Override

--- a/src/main/java/train/common/blocks/BlockWaterWheel.java
+++ b/src/main/java/train/common/blocks/BlockWaterWheel.java
@@ -64,7 +64,7 @@ public class BlockWaterWheel extends Block {
 			par1World.spawnParticle("splash", d0, par3 + 1, d2, 0.0D, 0.0D, 0.0D);
 			par1World.spawnParticle("splash", d0, par3, d2, 0.0D, 0.0D, 0.0D);
 			if (par5Random.nextInt(20) == 0) {
-				par1World.playSound(par2, par3, par4, "liquid.water", par5Random.nextFloat() * 0.25F + 0.75F, par5Random.nextFloat() * 1F + 0.1F, true);
+				CommonUtil.playSound(par1World, par2, par3, par4, "liquid.water", par5Random.nextFloat() * 0.25F + 0.75F, par5Random.nextFloat() * 1F + 0.1F, 0);
 			}
 		}
 	}

--- a/src/main/java/train/common/blocks/BlockWaterWheel.java
+++ b/src/main/java/train/common/blocks/BlockWaterWheel.java
@@ -2,6 +2,7 @@ package train.common.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -9,7 +10,6 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import train.common.Traincraft;
@@ -74,8 +74,8 @@ public class BlockWaterWheel extends Block {
 	 */
 	@Override
 	public void onBlockPlacedBy(World par1World, int par2, int par3, int par4, EntityLivingBase par5EntityLiving, ItemStack par6ItemStack) {
-		int l = MathHelper.floor_double((double) (par5EntityLiving.rotationYaw * 4.0F / 360.0F) + 0.5D) & 3;
-		int i1 = par1World.getBlockMetadata(par2, par3, par4) >> 2;
+		int l = CommonUtil.floorDouble((double) (par5EntityLiving.rotationYaw * 4.0F / 360.0F) + 0.5D) & 3;
+		int i1 = CommonUtil.getBlockFacing(par1World, par2, par3, par4) >> 2;
 		++l;
 		l %= 4;
 
@@ -112,7 +112,7 @@ public class BlockWaterWheel extends Block {
 	 */
 	@Override
 	public void breakBlock(World par1World, int par2, int par3, int par4, Block par5, int par6) {
-		int l = par1World.getBlockMetadata(par2, par3, par4);
+		int l = CommonUtil.getBlockFacing(par1World, par2, par3, par4);
 		TileEntity tile = par1World.getTileEntity(par2, par3, par4);
 		if (tile != null && tile instanceof TileWaterWheel) {
 			(tile).onChunkUnload();

--- a/src/main/java/train/common/blocks/BlockWaterWheel.java
+++ b/src/main/java/train/common/blocks/BlockWaterWheel.java
@@ -80,19 +80,19 @@ public class BlockWaterWheel extends Block {
 		l %= 4;
 
 		if (l == 0) {
-			par1World.setBlockMetadataWithNotify(par2, par3, par4, 2 | i1 << 2, 2);
+			CommonUtil.setBlockMeta(par1World, par2, par3, par4, 2 | i1 << 2);
 		}
 
 		if (l == 1) {
-			par1World.setBlockMetadataWithNotify(par2, par3, par4, 3 | i1 << 2, 2);
+			CommonUtil.setBlockMeta(par1World, par2, par3, par4, 3 | i1 << 2);
 		}
 
 		if (l == 2) {
-			par1World.setBlockMetadataWithNotify(par2, par3, par4, 0 | i1 << 2, 2);
+			CommonUtil.setBlockMeta(par1World, par2, par3, par4, 0 | i1 << 2);
 		}
 
 		if (l == 3) {
-			par1World.setBlockMetadataWithNotify(par2, par3, par4, 1 | i1 << 2, 2);
+			CommonUtil.setBlockMeta(par1World, par2, par3, par4, 1 | i1 << 2);
 		}
 	}
 

--- a/src/main/java/train/common/blocks/BlockWindMill.java
+++ b/src/main/java/train/common/blocks/BlockWindMill.java
@@ -74,19 +74,19 @@ public class BlockWindMill extends Block {
 		l %= 4;
 
 		if (l == 0) {
-			par1World.setBlockMetadataWithNotify(par2, par3, par4, 2 | i1 << 2, 2);
+			CommonUtil.setBlockMeta(par1World, par2, par3, par4, 2 | i1 << 2);
 		}
 
 		if (l == 1) {
-			par1World.setBlockMetadataWithNotify(par2, par3, par4, 3 | i1 << 2, 2);
+			CommonUtil.setBlockMeta(par1World, par2, par3, par4, 3 | i1 << 2);
 		}
 
 		if (l == 2) {
-			par1World.setBlockMetadataWithNotify(par2, par3, par4, 0 | i1 << 2, 2);
+			CommonUtil.setBlockMeta(par1World, par2, par3, par4, 0 | i1 << 2);
 		}
 
 		if (l == 3) {
-			par1World.setBlockMetadataWithNotify(par2, par3, par4, 1 | i1 << 2, 2);
+			CommonUtil.setBlockMeta(par1World, par2, par3, par4, 1 | i1 << 2);
 		}
 	}
 

--- a/src/main/java/train/common/blocks/BlockWindMill.java
+++ b/src/main/java/train/common/blocks/BlockWindMill.java
@@ -58,7 +58,7 @@ public class BlockWindMill extends Block {
 		TileEntity tile = par1World.getTileEntity(par2, par3, par4);
 		if (tile != null && tile instanceof TileWindMill && ((TileWindMill) tile).windClient > 0) {
 			if (par5Random.nextInt(20) == 0) {
-				par1World.playSound(par2, par3, par4, "minecart.inside", par5Random.nextFloat() * 0.25F + 0.1F, par5Random.nextFloat() * 1F - 0.6F, true);
+				CommonUtil.playSound(par1World, par2, par3, par4, "minecart.inside", par5Random.nextFloat() * 0.25F + 0.1F, par5Random.nextFloat() * 1F - 0.6F, 0);
 			}
 		}
 	}

--- a/src/main/java/train/common/blocks/BlockWindMill.java
+++ b/src/main/java/train/common/blocks/BlockWindMill.java
@@ -2,6 +2,7 @@ package train.common.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -9,7 +10,6 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import train.common.Traincraft;
 import train.common.library.Info;
@@ -68,8 +68,8 @@ public class BlockWindMill extends Block {
 	 */
 	@Override
 	public void onBlockPlacedBy(World par1World, int par2, int par3, int par4, EntityLivingBase par5EntityLiving, ItemStack par6ItemStack) {
-		int l = MathHelper.floor_double((double) (par5EntityLiving.rotationYaw * 4.0F / 360.0F) + 0.5D) & 3;
-		int i1 = par1World.getBlockMetadata(par2, par3, par4) >> 2;
+		int l = CommonUtil.floorDouble((double) (par5EntityLiving.rotationYaw * 4.0F / 360.0F) + 0.5D) & 3;
+		int i1 = CommonUtil.getBlockFacing(par1World, par2, par3, par4) >> 2;
 		++l;
 		l %= 4;
 

--- a/src/main/java/train/common/blocks/blockSwitch/BlockSpeedSign.java
+++ b/src/main/java/train/common/blocks/blockSwitch/BlockSpeedSign.java
@@ -1,5 +1,6 @@
 package train.common.blocks.blockSwitch;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.Entity;
@@ -9,7 +10,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.IIcon;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import train.common.api.blocks.BlockDynamic;
@@ -54,10 +54,10 @@ public class BlockSpeedSign extends BlockDynamic {
 		super.onBlockPlacedBy(world, i, j, k, entityliving, stack);
 		TileSpeedSign te = (TileSpeedSign) world.getTileEntity(i, j, k);
 		if (te != null) {
-			int dir = MathHelper.floor_double((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
+			int dir = CommonUtil.floorDouble((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
 			te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
 			te.setSkinstate(0);
-			world.markBlockForUpdate(i, j, k);
+			CommonUtil.markBlockForUpdate(world, i, j, k);
 
 
 		}
@@ -67,7 +67,7 @@ public class BlockSpeedSign extends BlockDynamic {
 	public boolean onBlockActivated(World p_149727_1_, int p_149727_2_, int p_149727_3_, int p_149727_4_, EntityPlayer p_149727_5_, int p_149727_6_, float p_149727_7_, float p_149727_8_, float p_149727_9_) {
 		TileSpeedSign te = (TileSpeedSign) p_149727_1_.getTileEntity(p_149727_2_, p_149727_3_, p_149727_4_);
 		te.increaseSkinState();
-		p_149727_1_.markBlockForUpdate(p_149727_2_, p_149727_3_, p_149727_4_);
+		CommonUtil.markBlockForUpdate(p_149727_1_, p_149727_2_, p_149727_3_, p_149727_4_);
 
 
 		return super.onBlockActivated(p_149727_1_, p_149727_2_, p_149727_3_, p_149727_4_, p_149727_5_, p_149727_6_, p_149727_7_, p_149727_8_, p_149727_9_);

--- a/src/main/java/train/common/blocks/blockSwitch/BlockkSignal.java
+++ b/src/main/java/train/common/blocks/blockSwitch/BlockkSignal.java
@@ -2,6 +2,7 @@ package train.common.blocks.blockSwitch;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.Entity;
@@ -11,7 +12,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.IIcon;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import train.common.Traincraft;
@@ -100,9 +100,9 @@ public class BlockkSignal extends Block {
         super.onBlockPlacedBy(world, i, j, k, entityliving, stack);
         TilekSignal te = (TilekSignal) world.getTileEntity(i, j, k);
         if (te != null) {
-            int dir = MathHelper.floor_double((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
+            int dir = CommonUtil.floorDouble((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
             te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
-            world.markBlockForUpdate(i, j, k);
+            CommonUtil.markBlockForUpdate(world, i, j, k);
         }
     }
 

--- a/src/main/java/train/common/blocks/blockSwitch/BlockoverheadWire.java
+++ b/src/main/java/train/common/blocks/blockSwitch/BlockoverheadWire.java
@@ -94,7 +94,7 @@ public class BlockoverheadWire extends Block {
             int i1 = CommonUtil.getBlockFacing(p_149727_1_, p_149727_2_, p_149727_3_, p_149727_4_);
             int j1 = i1 & 7;
             int k1 = 8 - (i1 & 8);
-            p_149727_1_.setBlockMetadataWithNotify(p_149727_2_, p_149727_3_, p_149727_4_, j1 + k1, 3);
+            CommonUtil.setBlockMeta(p_149727_1_, p_149727_2_, p_149727_3_, p_149727_4_, j1 + k1);
             p_149727_1_.playSoundEffect((double)p_149727_2_ + 0.5D, (double)p_149727_3_ + 0.5D, (double)p_149727_4_ + 0.5D, "random.click", 0.3F, k1 > 0 ? 0.6F : 0.5F);
             p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_, p_149727_4_, this);
 

--- a/src/main/java/train/common/blocks/blockSwitch/BlockoverheadWire.java
+++ b/src/main/java/train/common/blocks/blockSwitch/BlockoverheadWire.java
@@ -2,6 +2,7 @@ package train.common.blocks.blockSwitch;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.Entity;
@@ -11,7 +12,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.IIcon;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -76,9 +76,9 @@ public class BlockoverheadWire extends Block {
         super.onBlockPlacedBy(world, i, j, k, entityliving, stack);
         TileoverheadWire te = (TileoverheadWire) world.getTileEntity(i, j, k);
         if (te != null) {
-            int dir = MathHelper.floor_double((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
+            int dir = CommonUtil.floorDouble((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
             te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
-            world.markBlockForUpdate(i, j, k);
+            CommonUtil.markBlockForUpdate(world, i, j, k);
         }
     }
 
@@ -91,7 +91,7 @@ public class BlockoverheadWire extends Block {
         }
         else
         {
-            int i1 = p_149727_1_.getBlockMetadata(p_149727_2_, p_149727_3_, p_149727_4_);
+            int i1 = CommonUtil.getBlockFacing(p_149727_1_, p_149727_2_, p_149727_3_, p_149727_4_);
             int j1 = i1 & 7;
             int k1 = 8 - (i1 & 8);
             p_149727_1_.setBlockMetadataWithNotify(p_149727_2_, p_149727_3_, p_149727_4_, j1 + k1, 3);
@@ -171,12 +171,12 @@ public class BlockoverheadWire extends Block {
 
     public int isProvidingWeakPower(IBlockAccess p_149709_1_, int p_149709_2_, int p_149709_3_, int p_149709_4_, int p_149709_5_)
     {
-        return (p_149709_1_.getBlockMetadata(p_149709_2_, p_149709_3_, p_149709_4_) & 8) > 0 ? 15 : 0;
+        return (CommonUtil.getBlockFacing(p_149709_1_, p_149709_2_, p_149709_3_, p_149709_4_) & 8) > 0 ? 15 : 0;
     }
 
     public int isProvidingStrongPower(IBlockAccess p_149748_1_, int p_149748_2_, int p_149748_3_, int p_149748_4_, int p_149748_5_)
     {
-        int i1 = p_149748_1_.getBlockMetadata(p_149748_2_, p_149748_3_, p_149748_4_);
+        int i1 = CommonUtil.getBlockFacing(p_149748_1_, p_149748_2_, p_149748_3_, p_149748_4_);
 
         if ((i1 & 8) == 0)
         {

--- a/src/main/java/train/common/blocks/blockSwitch/BlockoverheadWireDouble.java
+++ b/src/main/java/train/common/blocks/blockSwitch/BlockoverheadWireDouble.java
@@ -2,6 +2,7 @@ package train.common.blocks.blockSwitch;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.Entity;
@@ -10,7 +11,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.IIcon;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import train.common.Traincraft;
@@ -74,9 +74,9 @@ public class BlockoverheadWireDouble extends Block {
         super.onBlockPlacedBy(world, i, j, k, entityliving, stack);
         TileoverheadWireDouble te = (TileoverheadWireDouble) world.getTileEntity(i, j, k);
         if (te != null) {
-            int dir = MathHelper.floor_double((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
+            int dir = CommonUtil.floorDouble((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
             te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
-            world.markBlockForUpdate(i, j, k);
+            CommonUtil.markBlockForUpdate(world, i, j, k);
         }
     }
 

--- a/src/main/java/train/common/blocks/blockSwitch/BlocksignalSpanish.java
+++ b/src/main/java/train/common/blocks/blockSwitch/BlocksignalSpanish.java
@@ -2,6 +2,7 @@ package train.common.blocks.blockSwitch;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.Entity;
@@ -11,7 +12,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.IIcon;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import train.common.Traincraft;
@@ -69,7 +69,7 @@ public class BlocksignalSpanish extends Block {
 
             te.state = 1;
         }
-        /* int l = world.getBlockMetadata(i, j, k); if (l == 2) {
+        /* int l = CommonUtil.getBlockFacing(world, i, j, k); if (l == 2) {
          *
          * te.rot = 2; } if (l == 5) {
          *
@@ -100,9 +100,9 @@ public class BlocksignalSpanish extends Block {
         super.onBlockPlacedBy(world, i, j, k, entityliving, stack);
         TilesignalSpanish te = (TilesignalSpanish) world.getTileEntity(i, j, k);
         if (te != null) {
-            int dir = MathHelper.floor_double((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
+            int dir = CommonUtil.floorDouble((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
             te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
-            world.markBlockForUpdate(i, j, k);
+            CommonUtil.markBlockForUpdate(world, i, j, k);
         }
     }
 
@@ -162,12 +162,12 @@ public class BlocksignalSpanish extends Block {
     /*
     public int isProvidingWeakPower(IBlockAccess p_149709_1_, int p_149709_2_, int p_149709_3_, int p_149709_4_, int p_149709_5_)
     {
-        return (p_149709_1_.getBlockMetadata(p_149709_2_, p_149709_3_, p_149709_4_) & 8) > 0 ? 15 : 0;
+        return (CommonUtil.getBlockFacing(p_149709_1_, p_149709_2_, p_149709_3_, p_149709_4_) & 8) > 0 ? 15 : 0;
     }
 
     public int isProvidingStrongPower(IBlockAccess p_149748_1_, int p_149748_2_, int p_149748_3_, int p_149748_4_, int p_149748_5_)
     {
-        int i1 = p_149748_1_.getBlockMetadata(p_149748_2_, p_149748_3_, p_149748_4_);
+        int i1 = CommonUtil.getBlockFacing(p_149748_1_, p_149748_2_, p_149748_3_, p_149748_4_);
 
         if ((i1 & 8) == 0)
         {
@@ -194,7 +194,7 @@ public class BlocksignalSpanish extends Block {
         if (te.getState() == 0 && world.isBlockIndirectlyGettingPowered(i, j, k)) {
             te.setState(1);
         }
-        world.markBlockForUpdate(i, j, k);
+        CommonUtil.markBlockForUpdate(world, i, j, k);
     }
 
     public void updateTick(World world, int i, int j, int k) {
@@ -203,7 +203,7 @@ public class BlocksignalSpanish extends Block {
         if (te == null)
             return;
         //te.rot = l;
-        // int l = world.getBlockMetadata(i, j, k);
+        // int l = CommonUtil.getBlockFacing(world, i, j, k);
         if (te.state == 1 && !world.isBlockIndirectlyGettingPowered(i, j, k)) {
             te.state = 0;
         }

--- a/src/main/java/train/common/blocks/switchStand/BlockAutoSwitchStand.java
+++ b/src/main/java/train/common/blocks/switchStand/BlockAutoSwitchStand.java
@@ -1,10 +1,10 @@
 package train.common.blocks.switchStand;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import train.common.Traincraft;
@@ -25,7 +25,7 @@ public class BlockAutoSwitchStand extends BlockSwitch {
     @Override
     public void onBlockAdded(World world, int i, int j, int k) {
         super.onBlockAdded(world, i, j, k);
-        world.markBlockForUpdate(i, j, k);
+        CommonUtil.markBlockForUpdate(world, i, j, k);
     }
 
     @Override
@@ -33,9 +33,9 @@ public class BlockAutoSwitchStand extends BlockSwitch {
         super.onBlockPlacedBy(world, i, j, k, entityliving, stack);
         TileAutoSwitchStand te = (TileAutoSwitchStand) world.getTileEntity(i, j, k);
         if (te != null) {
-            int dir = MathHelper.floor_double((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
+            int dir = CommonUtil.floorDouble((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
             te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
-            world.markBlockForUpdate(i, j, k);
+            CommonUtil.markBlockForUpdate(world, i, j, k);
         }
     }
 

--- a/src/main/java/train/common/blocks/switchStand/BlockCircleSwitchStand.java
+++ b/src/main/java/train/common/blocks/switchStand/BlockCircleSwitchStand.java
@@ -1,10 +1,10 @@
 package train.common.blocks.switchStand;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import train.common.Traincraft;
@@ -25,7 +25,7 @@ public class BlockCircleSwitchStand extends BlockSwitch {
     @Override
     public void onBlockAdded(World world, int i, int j, int k) {
         super.onBlockAdded(world, i, j, k);
-        world.markBlockForUpdate(i, j, k);
+        CommonUtil.markBlockForUpdate(world, i, j, k);
     }
 
     @Override
@@ -33,9 +33,9 @@ public class BlockCircleSwitchStand extends BlockSwitch {
         super.onBlockPlacedBy(world, i, j, k, entityliving, stack);
         TileCircleSwitchStand te = (TileCircleSwitchStand) world.getTileEntity(i, j, k);
         if (te != null) {
-            int dir = MathHelper.floor_double((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
+            int dir = CommonUtil.floorDouble((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
             te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
-            world.markBlockForUpdate(i, j, k);
+            CommonUtil.markBlockForUpdate(world, i, j, k);
         }
     }
 

--- a/src/main/java/train/common/blocks/switchStand/BlockMILWSwitchStand.java
+++ b/src/main/java/train/common/blocks/switchStand/BlockMILWSwitchStand.java
@@ -1,10 +1,10 @@
 package train.common.blocks.switchStand;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import train.common.Traincraft;
@@ -25,7 +25,7 @@ public class BlockMILWSwitchStand extends BlockSwitch {
     @Override
     public void onBlockAdded(World world, int i, int j, int k) {
         super.onBlockAdded(world, i, j, k);
-        world.markBlockForUpdate(i, j, k);
+        CommonUtil.markBlockForUpdate(world, i, j, k);
     }
 
     @Override
@@ -33,9 +33,9 @@ public class BlockMILWSwitchStand extends BlockSwitch {
         super.onBlockPlacedBy(world, i, j, k, entityliving, stack);
         TileMILWSwitchStand te = (TileMILWSwitchStand) world.getTileEntity(i, j, k);
         if (te != null) {
-            int dir = MathHelper.floor_double((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
+            int dir = CommonUtil.floorDouble((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
             te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
-            world.markBlockForUpdate(i, j, k);
+            CommonUtil.markBlockForUpdate(world, i, j, k);
         }
     }
 

--- a/src/main/java/train/common/blocks/switchStand/BlockOWOSwitchStand.java
+++ b/src/main/java/train/common/blocks/switchStand/BlockOWOSwitchStand.java
@@ -1,10 +1,10 @@
 package train.common.blocks.switchStand;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import train.common.Traincraft;
@@ -25,7 +25,7 @@ public class BlockOWOSwitchStand extends BlockSwitch {
     @Override
     public void onBlockAdded(World world, int i, int j, int k) {
         super.onBlockAdded(world, i, j, k);
-        world.markBlockForUpdate(i, j, k);
+        CommonUtil.markBlockForUpdate(world, i, j, k);
     }
 
     @Override
@@ -33,9 +33,9 @@ public class BlockOWOSwitchStand extends BlockSwitch {
         super.onBlockPlacedBy(world, i, j, k, entityliving, stack);
         TileOWOSwitchStand te = (TileOWOSwitchStand) world.getTileEntity(i, j, k);
         if (te != null) {
-            int dir = MathHelper.floor_double((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
+            int dir = CommonUtil.floorDouble((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
             te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
-            world.markBlockForUpdate(i, j, k);
+            CommonUtil.markBlockForUpdate(world, i, j, k);
         }
     }
 

--- a/src/main/java/train/common/blocks/switchStand/BlockOWOYardSwitchStand.java
+++ b/src/main/java/train/common/blocks/switchStand/BlockOWOYardSwitchStand.java
@@ -1,10 +1,10 @@
 package train.common.blocks.switchStand;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import train.common.Traincraft;
@@ -25,7 +25,7 @@ public class BlockOWOYardSwitchStand extends BlockSwitch {
     @Override
     public void onBlockAdded(World world, int i, int j, int k) {
         super.onBlockAdded(world, i, j, k);
-        world.markBlockForUpdate(i, j, k);
+        CommonUtil.markBlockForUpdate(world, i, j, k);
     }
 
     @Override
@@ -33,9 +33,9 @@ public class BlockOWOYardSwitchStand extends BlockSwitch {
         super.onBlockPlacedBy(world, i, j, k, entityliving, stack);
         TileOWOYardSwitchStand te = (TileOWOYardSwitchStand) world.getTileEntity(i, j, k);
         if (te != null) {
-            int dir = MathHelper.floor_double((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
+            int dir = CommonUtil.floorDouble((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
             te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
-            world.markBlockForUpdate(i, j, k);
+            CommonUtil.markBlockForUpdate(world, i, j, k);
         }
     }
 

--- a/src/main/java/train/common/blocks/switchStand/BlockSwitchStand.java
+++ b/src/main/java/train/common/blocks/switchStand/BlockSwitchStand.java
@@ -2,11 +2,11 @@ package train.common.blocks.switchStand;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import train.common.Traincraft;
@@ -66,9 +66,9 @@ public class BlockSwitchStand extends BlockSwitch {
 		super.onBlockPlacedBy(world, i, j, k, entityliving, stack);
 		TileSwitchStand te = (TileSwitchStand) world.getTileEntity(i, j, k);
 		if (te != null) {
-			int dir = MathHelper.floor_double((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
+			int dir = CommonUtil.floorDouble((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
 			te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
-			world.markBlockForUpdate(i, j, k);
+			CommonUtil.markBlockForUpdate(world, i, j, k);
 		}
 	}
 

--- a/src/main/java/train/common/blocks/tracks/BlockEnergyTrack.java
+++ b/src/main/java/train/common/blocks/tracks/BlockEnergyTrack.java
@@ -8,6 +8,7 @@ package train.common.blocks.tracks;
 import cofh.api.energy.IEnergyHandler;
 import cofh.api.energy.IEnergyProvider;
 import cpw.mods.fml.common.FMLCommonHandler;
+import ebf.tim.utility.CommonUtil;
 import ebf.tim.utility.DebugUtil;
 import mods.railcraft.api.core.items.IToolCrowbar;
 import mods.railcraft.api.electricity.IElectricGrid;
@@ -54,7 +55,7 @@ public class BlockEnergyTrack extends TrackBaseTraincraft implements ITrackPower
 
 	private Block getThisBlock() {
 		if (thisBlock == null) {
-			thisBlock = getWorld().getBlock(getX(), getY(), getZ());
+			thisBlock = CommonUtil.getBlockAt(getWorld(), getX(), getY(), getZ());
 		}
 		return thisBlock;
 	}
@@ -150,7 +151,7 @@ public class BlockEnergyTrack extends TrackBaseTraincraft implements ITrackPower
 	}
 
 	private void notifyNeighbors() {
-		Block block = getWorld().getBlock(getX(), getY(), getZ());
+		Block block = CommonUtil.getBlockAt(getWorld(), getX(), getY(), getZ());
 		getWorld().notifyBlocksOfNeighborChange(getX(), getY(), getZ(), block);
 		getWorld().notifyBlocksOfNeighborChange(getX(), getY() - 1, getZ(), block);
 

--- a/src/main/java/train/common/core/CreativeTabTraincraft.java
+++ b/src/main/java/train/common/core/CreativeTabTraincraft.java
@@ -9,10 +9,10 @@ package train.common.core;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.StatCollector;
 import train.common.library.TraincraftRegistry;
 
 import java.util.List;
@@ -38,7 +38,7 @@ public class CreativeTabTraincraft extends CreativeTabs {
 
     @Override
     public String getTranslatedTabLabel() {
-        return StatCollector.translateToLocal(super.getTabLabel());
+        return CommonUtil.translate(super.getTabLabel());
     }
 
     /**the icon for the tab. override this one*/

--- a/src/main/java/train/common/core/HandleMaxAttachedCarts.java
+++ b/src/main/java/train/common/core/HandleMaxAttachedCarts.java
@@ -1,5 +1,6 @@
 package train.common.core;
 
+import ebf.tim.utility.CommonUtil;
 import train.common.api.AbstractTrains;
 import train.common.api.Locomotive;
 
@@ -24,7 +25,7 @@ public class HandleMaxAttachedCarts {
 
         // Debuffs
         Loco.currentSpeedSlowDown = Loco.currentMassPulled / totalMhp * 74.57;
-        Loco.currentBrakeSlowDown = Math.pow(Loco.currentMassPulled,2) / totalMhp * 0.7457 * 0.8;
+        Loco.currentBrakeSlowDown = CommonUtil.power((float) Loco.currentMassPulled, 2) / totalMhp * 0.7457 * 0.8;
         Loco.currentAccelSlowDown = Loco.currentBrakeSlowDown * 1.13;
         Loco.currentFuelConsumptionChange = Loco.currentBrakeSlowDown * 100;
 

--- a/src/main/java/train/common/core/TrainModBlockUtil.java
+++ b/src/main/java/train/common/core/TrainModBlockUtil.java
@@ -1,5 +1,6 @@
 package train.common.core;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
@@ -8,13 +9,13 @@ import java.util.ArrayList;
 
 public class TrainModBlockUtil {
     public static ArrayList<ItemStack> getItemStackFromBlock(World world, int i, int j, int k) {
-        Block block = world.getBlock(i, j, k);
+        Block block = CommonUtil.getBlockAt(world, i, j, k);
 
         if (block == null) {
             return null;
         }
 
-        int meta = world.getBlockMetadata(i, j, k);
+        int meta = CommonUtil.getBlockFacing(world, i, j, k);
         return block.getDrops(world, i, j, k, meta, 0);
     }
 }

--- a/src/main/java/train/common/core/util/TraincraftUtil.java
+++ b/src/main/java/train/common/core/util/TraincraftUtil.java
@@ -36,10 +36,6 @@ public class TraincraftUtil {
                         || item2.getItemDamage() == OreDictionary.WILDCARD_VALUE);
     }
 
-    public static boolean isRailBlockAt(World world, int x, int y, int z) {
-        return world.getBlock(x, y, z) instanceof BlockRailBase;
-    }
-
     public static final double degrees = (180d / Math.PI);
     public static final double radian = (Math.PI / 180.0D);
 
@@ -76,50 +72,7 @@ public class TraincraftUtil {
         }
     }
 
-    public static float atan2f(double x, double z) {
-        float pi = -3.141592653f;
-        float multiplier = 1.0f;
-
-        if (z < 0.0d) {
-            if (x < 0.0d) {
-                z = -z;
-                x = -x;
-            } else {
-                z = -z;
-                multiplier = -1.0f;
-            }
-
-        } else {
-            if (x < 0.0d) {
-                x = -x;
-                multiplier = -1.0f;
-            }
-
-            pi = 0.0f;
-        }
-
-        double invDiv = 1.0D / ((Math.max(z, x)) * (1.0D / (ATAN2_SQRT - 1)));
-        return (atan2[(int) (x * invDiv) * ATAN2_SQRT + (int) (z * invDiv)] + pi) * multiplier;
-    }
-
-    public static float atan2degreesf(double x, double y) {
-        return atan2f(x, y) * degreesF;
-    }
-
-    private static final int ATAN2_SQRT = (int) Math.sqrt(1024);
-    private static final float[] atan2 = new float[1024];
-
-    static {
-        for (int i = 0; i < ATAN2_SQRT; i++) {
-            for (int j = 0; j < ATAN2_SQRT; j++) {
-                atan2[j * ATAN2_SQRT + i] = (float) Math.atan2((float) j / ATAN2_SQRT, (float) i / ATAN2_SQRT);
-            }
-        }
-    }
-
-    public static final float degreesF = (float) (180.0d / Math.PI);
-
     public static Vec3 func_514_g(double d, double d1, double d2) {
-        return Vec3.createVectorHelper(MathHelper.floor_double(d), MathHelper.floor_double(d1), MathHelper.floor_double(d2));
+        return Vec3.createVectorHelper(CommonUtil.floorDouble(d), CommonUtil.floorDouble(d1), CommonUtil.floorDouble(d2));
     }
 }

--- a/src/main/java/train/common/core/util/TraincraftUtil.java
+++ b/src/main/java/train/common/core/util/TraincraftUtil.java
@@ -48,11 +48,11 @@ public class TraincraftUtil {
             return;
         }
         double pitchRads = transport.rotationPitch * radian;
-        double rotationCos1 = Math.cos(Math.toRadians(transport.rotationYaw + ((transport instanceof Locomotive) ? 90 : 180)));
-        double rotationSin1 = Math.sin(Math.toRadians(transport.rotationYaw + ((transport instanceof Locomotive) ? 90 : 180)));
+        double rotationCos1 = Math.cos((transport.rotationYaw + ((transport instanceof Locomotive) ? 90 : 180)) * radian);
+        double rotationSin1 = Math.sin((transport.rotationYaw + ((transport instanceof Locomotive) ? 90 : 180)) * radian);
         if (!Traincraft.proxy.isClient()) {
-            rotationCos1 = Math.cos(Math.toRadians(transport.rotationYaw + 90));
-            rotationSin1 = Math.sin(Math.toRadians((transport.rotationYaw + 90)));
+            rotationCos1 = Math.cos((transport.rotationYaw + 90) * radian);
+            rotationSin1 = Math.sin((transport.rotationYaw + 90) * radian);
         }
         float pitch = (float) (transport.posY + ((Math.tan(pitchRads) * distance) + transport.getMountedYOffset())
                 + transport.riddenByEntity.getYOffset() + yOffset);

--- a/src/main/java/train/common/core/util/TraincraftUtil.java
+++ b/src/main/java/train/common/core/util/TraincraftUtil.java
@@ -1,11 +1,9 @@
 package train.common.core.util;
 
-import net.minecraft.block.BlockRailBase;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.MathHelper;
 import net.minecraft.util.Vec3;
-import net.minecraft.world.World;
 import net.minecraftforge.oredict.OreDictionary;
 import train.common.Traincraft;
 import train.common.api.EntityRollingStock;

--- a/src/main/java/train/common/entity/EntityLasersLines.java
+++ b/src/main/java/train/common/entity/EntityLasersLines.java
@@ -87,11 +87,11 @@ public class EntityLasersLines extends Entity {
 
 		renderSize = Math.sqrt(dx * dx + dy * dy + dz * dz);
 
-		angleZ = 360 - (Math.atan2(dz, dx) * 180.0 / Math.PI + 180.0);
+		angleZ = 360 - (CommonUtil.atan2degreesf(dz, dx) + 180.0);
 
 		dx = Math.sqrt(renderSize * renderSize - dy * dy);
 
-		angleY = -Math.atan2(dy, dx) * 180 / Math.PI;
+		angleY = -CommonUtil.atan2degreesf(dy, dx);
 	}
 
 	@Override

--- a/src/main/java/train/common/entity/EntityLasersLines.java
+++ b/src/main/java/train/common/entity/EntityLasersLines.java
@@ -1,5 +1,6 @@
 package train.common.entity;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.entity.Entity;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;

--- a/src/main/java/train/common/entity/ai/EntityAIFearHorn.java
+++ b/src/main/java/train/common/entity/ai/EntityAIFearHorn.java
@@ -1,11 +1,11 @@
 package train.common.entity.ai;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.ai.EntityAIBase;
 import net.minecraft.entity.ai.RandomPositionGenerator;
 import net.minecraft.entity.passive.EntityAnimal;
 import net.minecraft.pathfinding.PathEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.ChunkCache;
 import train.common.api.Locomotive;
@@ -60,7 +60,7 @@ public class EntityAIFearHorn extends EntityAIBase {
      * Returns the path to the given coordinates
      */
     private PathEntity getPathToXYZ(double x, double y, double z) {
-        return getEntityPathToXYZ(MathHelper.floor_double(x), (int) y, MathHelper.floor_double(z),
+        return getEntityPathToXYZ(CommonUtil.floorDouble(x), (int) y, CommonUtil.floorDouble(z),
                 entity.getNavigator().getPathSearchRange(), false, false, false);
     }
 
@@ -68,14 +68,14 @@ public class EntityAIFearHorn extends EntityAIBase {
      * Try to find and set a path to XYZ. Returns true if successful.
      */
     private boolean tryMoveToXYZ(double x, double y, double z, double speed) {
-        PathEntity pathentity = this.getPathToXYZ((double) MathHelper.floor_double(x), (double) ((int) y), (double) MathHelper.floor_double(z));
+        PathEntity pathentity = this.getPathToXYZ((double) CommonUtil.floorDouble(x), (double) ((int) y), (double) CommonUtil.floorDouble(z));
         return entity.getNavigator().setPath(pathentity, speed);
     }
 
     private PathEntity getEntityPathToXYZ(int targetX, int targetY, int targetZ, float range, boolean canPassOpenDoor, boolean canPassClosedDoor, boolean canSwim) {
-        int x = MathHelper.floor_double(entity.posX);
-        int y = MathHelper.floor_double(entity.posY);
-        int z = MathHelper.floor_double(entity.posZ);
+        int x = CommonUtil.floorDouble(entity.posX);
+        int y = CommonUtil.floorDouble(entity.posY);
+        int z = CommonUtil.floorDouble(entity.posZ);
         int r = (int) (range + 8.0F);
         int xmin = x - r;
         int ymin = y - r;

--- a/src/main/java/train/common/entity/ai/TCPathFinder.java
+++ b/src/main/java/train/common/entity/ai/TCPathFinder.java
@@ -1,12 +1,12 @@
 package train.common.entity.ai;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.Entity;
 import net.minecraft.init.Blocks;
 import net.minecraft.pathfinding.PathFinder;
 import net.minecraft.pathfinding.PathPoint;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import train.common.blocks.BlockTCRail;
 import train.common.blocks.BlockTCRailGag;
@@ -35,7 +35,7 @@ public class TCPathFinder extends PathFinder {
         for (int i = x; i < x + point.xCoord; ++i) {
             for (int j = y; j < y + point.yCoord; ++j) {
                 for (int k = z; k < z + point.zCoord; ++k) {
-                    Block block = entity.worldObj.getBlock(i, j, k);
+                    Block block = CommonUtil.getBlockAt(entity.worldObj, i, j, k);
 
                     if (block.getMaterial() != Material.air) {
                         if (block == Blocks.trapdoor) {
@@ -57,12 +57,12 @@ public class TCPathFinder extends PathFinder {
                             k1=9;
                         }
 
-                        if (entity.worldObj.getBlock(i, j, k).getRenderType() == 9) {
-                            int j2 = MathHelper.floor_double(entity.posX);
-                            int l1 = MathHelper.floor_double(entity.posY);
-                            int i2 = MathHelper.floor_double(entity.posZ);
+                        if (CommonUtil.getBlockAt(entity.worldObj, i, j, k).getRenderType() == 9) {
+                            int j2 = CommonUtil.floorDouble(entity.posX);
+                            int l1 = CommonUtil.floorDouble(entity.posY);
+                            int i2 = CommonUtil.floorDouble(entity.posZ);
 
-                            if (entity.worldObj.getBlock(j2, l1, i2).getRenderType() != 9 && entity.worldObj.getBlock(j2, l1 - 1, i2).getRenderType() != 9) {
+                            if (CommonUtil.getBlockAt(entity.worldObj, j2, l1, i2).getRenderType() != 9 && CommonUtil.getBlockAt(entity.worldObj, j2, l1 - 1, i2).getRenderType() != 9) {
                                 return -3;
                             }
                         } else if (!block.getBlocksMovement(entity.worldObj, i, j, k) && (!movement || block != Blocks.wooden_door)) {

--- a/src/main/java/train/common/entity/digger/EntityRotativeDigger.java
+++ b/src/main/java/train/common/entity/digger/EntityRotativeDigger.java
@@ -478,7 +478,7 @@ public class EntityRotativeDigger extends Entity implements IInventory {
             double db = 0 - vecLook.xCoord;
             double dc = 0 - vecLook.zCoord;
             if (db * db + dc * dc > 0.0000001D) {
-                da = (float) ((Math.atan2(dc, db) * 180D) / 3.1415926535897931D);
+                da = CommonUtil.atan2degreesf(dc, db);
             }
 
             double d19;
@@ -581,10 +581,10 @@ public class EntityRotativeDigger extends Entity implements IInventory {
         riddenByEntity.setPosition(posX, posY + getMountedYOffset() + riddenByEntity.getYOffset() + 1.1F, posZ);
         if (riddenByEntity instanceof EntityLiving) {
             pitch = riddenByEntity.rotationPitch;
-            if (pitch > Math.toDegrees(pitchLimits))
-                pitch = (float) Math.toDegrees(pitchLimits);
-            if (pitch < Math.toDegrees(-pitchLimits))
-                pitch = (float) Math.toDegrees(-pitchLimits);
+            if (pitch > pitchLimits * CommonUtil.degreesF)
+                pitch = pitchLimits * CommonUtil.degreesF;
+            if (pitch < -pitchLimits * CommonUtil.degreesF)
+                pitch = -pitchLimits * CommonUtil.degreesF;
         }
     }
 

--- a/src/main/java/train/common/entity/digger/EntityRotativeDigger.java
+++ b/src/main/java/train/common/entity/digger/EntityRotativeDigger.java
@@ -2,6 +2,7 @@ package train.common.entity.digger;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.Minecraft;
@@ -519,7 +520,7 @@ public class EntityRotativeDigger extends Entity implements IInventory {
 
         if (Math.sqrt((motionX * motionX) + (motionZ * motionZ)) > 0.01) {
             Vec3 pos = Vec3.createVectorHelper(posX, posY - 1, posZ);
-            Block id = worldObj.getBlock((int) posX, (int) posY - 1, (int) posZ);
+            Block id = CommonUtil.getBlockAt(worldObj, (int) posX, (int) posY - 1, (int) posZ);
 
             if (id != null) {
                 this.playMiningEffect(pos, Block.getIdFromBlock(id));
@@ -535,7 +536,7 @@ public class EntityRotativeDigger extends Entity implements IInventory {
      */
 
     private void playMiningEffect(Vec3 pos, int block_index) {
-        Block id = worldObj.getBlock((int) pos.xCoord, (int) pos.yCoord, (int) pos.zCoord);
+        Block id = CommonUtil.getBlockAt(worldObj, (int) pos.xCoord, (int) pos.yCoord, (int) pos.zCoord);
         if (id != null) {
             Minecraft.getMinecraft().effectRenderer.addBlockHitEffects((int) pos.xCoord, (int) pos.yCoord, (int) pos.zCoord, block_index < 4 ? getSideFromYaw() : (block_index < 6 ? 1 : 0));
         }

--- a/src/main/java/train/common/entity/digger/EntityRotativeWheel.java
+++ b/src/main/java/train/common/entity/digger/EntityRotativeWheel.java
@@ -2,6 +2,7 @@ package train.common.entity.digger;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockLiquid;
 import net.minecraft.block.BlockTorch;
@@ -163,8 +164,8 @@ public class EntityRotativeWheel extends Entity {
             return;
         }
 
-        Block id = worldObj.getBlock((int) pos.xCoord, (int) pos.yCoord, (int) pos.zCoord);
-        int meta = worldObj.getBlockMetadata((int) pos.xCoord, (int) pos.yCoord, (int) pos.zCoord);
+        Block id = CommonUtil.getBlockAt(worldObj, (int) pos.xCoord, (int) pos.yCoord, (int) pos.zCoord);
+        int meta = CommonUtil.getBlockFacing(worldObj, (int) pos.xCoord, (int) pos.yCoord, (int) pos.zCoord);
         if (id != null) {
             this.playMiningEffect(pos, id);
         }
@@ -209,7 +210,7 @@ public class EntityRotativeWheel extends Entity {
     @SideOnly(Side.CLIENT)
     private void playMiningEffect(Vec3 pos, Block block_index) {
         miningTickCounter++;
-        Block id = worldObj.getBlock((int) pos.xCoord, (int) pos.yCoord, (int) pos.zCoord);
+        Block id = CommonUtil.getBlockAt(worldObj, (int) pos.xCoord, (int) pos.yCoord, (int) pos.zCoord);
     }
 
     /**

--- a/src/main/java/train/common/entity/rollingStockOld/special/EntityTracksBuilder.java
+++ b/src/main/java/train/common/entity/rollingStockOld/special/EntityTracksBuilder.java
@@ -38,7 +38,6 @@ import train.common.blocks.BlockTCRail;
 import train.common.blocks.BlockTCRailGag;
 import train.common.core.handlers.FuelHandler;
 import train.common.core.plugins.PluginRailcraft;
-import train.common.core.util.TraincraftUtil;
 import train.common.items.ItemTCRail;
 import train.common.library.GuiIDs;
 
@@ -687,13 +686,13 @@ public class EntityTracksBuilder extends EntityRollingStock implements IInventor
 				}
 				return lastFace;
 			}
-			rotation = TraincraftUtil.atan2degreesf(d7,d6);
-			lastFace = MathHelper.floor_double(rotation * 4.0F / 360.0F + 0.5D) & 3;
+			rotation = CommonUtil.atan2degreesf(d7,d6);
+			lastFace = CommonUtil.floorDouble(rotation * 4.0F / 360.0F + 0.5D) & 3;
 		}
 		else {
-			rotation = (TraincraftUtil.atan2degreesf(0 - motionX, 0 - motionZ));
+			rotation = (CommonUtil.atan2degreesf(0 - motionX, 0 - motionZ));
 		}
-		return MathHelper.floor_double(rotation * 4.0F / 360.0F + 0.5D) & 3;
+		return CommonUtil.floorDouble(rotation * 4.0F / 360.0F + 0.5D) & 3;
 	}
 
 	/** Compares the currentHeight with given height in GUI */

--- a/src/main/java/train/common/entity/rollingStockOld/special/EntityTracksBuilder.java
+++ b/src/main/java/train/common/entity/rollingStockOld/special/EntityTracksBuilder.java
@@ -3,6 +3,7 @@ package train.common.entity.rollingStockOld.special;
 import com.mojang.authlib.GameProfile;
 import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.common.FMLCommonHandler;
+import ebf.tim.utility.CommonUtil;
 import mods.railcraft.api.core.items.ITrackItem;
 import mods.railcraft.api.tracks.RailTools;
 import net.minecraft.block.Block;
@@ -145,9 +146,9 @@ public class EntityTracksBuilder extends EntityRollingStock implements IInventor
 
 		updatePushForces();
 		
-		int i = MathHelper.floor_double(posX);
-		int j = MathHelper.floor_double(posY);
-		int k = MathHelper.floor_double(posZ);
+		int i = CommonUtil.floorDouble(posX);
+		int j = CommonUtil.floorDouble(posY);
+		int k = CommonUtil.floorDouble(posZ);
 		
 		if(this.skipTick) {
 			this.skipTick = false;
@@ -627,7 +628,7 @@ public class EntityTracksBuilder extends EntityRollingStock implements IInventor
 		miningTickCounter++;
 
 		if (!FMLCommonHandler.instance().getMinecraftServerInstance().isDedicatedServer() && pos != null && worldObj !=null) {
-			Block block = worldObj.getBlock((int) pos.xCoord, (int) pos.yCoord, (int) pos.zCoord);
+			Block block = CommonUtil.getBlockAt(worldObj, (int) pos.xCoord, (int) pos.yCoord, (int) pos.zCoord);
 			if (miningTickCounter % 8 == 0 && block != null && !worldObj.isRemote && Minecraft.getMinecraft() != null) {
 				this.worldObj.playSound((int) pos.xCoord + 0.5F, (int) pos.yCoord + 0.5F, (int) pos.zCoord + 0.5F, block.stepSound.getBreakSound(), 1.0F, block.stepSound.getPitch() * 0.5F, true);
 			}
@@ -791,9 +792,9 @@ public class EntityTracksBuilder extends EntityRollingStock implements IInventor
 
 	private void harvestBlock(int i, int j, int k) {
 
-		Block block =  worldObj.getBlock(i, j, k);
+		Block block =  CommonUtil.getBlockAt(worldObj, i, j, k);
 
-		int meta = worldObj.getBlockMetadata(i, j, k);
+		int meta = CommonUtil.getBlockFacing(worldObj, i, j, k);
 
 		if (block.getDrops(worldObj, i, j, k, meta, 0).size()>0) {
 
@@ -848,8 +849,8 @@ public class EntityTracksBuilder extends EntityRollingStock implements IInventor
 		}
 
 
-		Block block = worldObj.getBlock(i, j, k);
-		int metadata = worldObj.getBlockMetadata(i, j, k);
+		Block block = CommonUtil.getBlockAt(worldObj, i, j, k);
+		int metadata = CommonUtil.getBlockFacing(worldObj, i, j, k);
 
 		if(block == newblock && metadata == newmeta)
 			return true;
@@ -888,8 +889,8 @@ public class EntityTracksBuilder extends EntityRollingStock implements IInventor
 		if(BuilderInvent[inventoryId] == null)
 			return false;
 
-		Block block = worldObj.getBlock(i, j, k);
-		int metadata = worldObj.getBlockMetadata(i, j, k);
+		Block block = CommonUtil.getBlockAt(worldObj, i, j, k);
+		int metadata = CommonUtil.getBlockFacing(worldObj, i, j, k);
 
 			// check if we need to place rails and if we can
 		if(BlockRailBase.func_150051_a(block)
@@ -938,7 +939,7 @@ public class EntityTracksBuilder extends EntityRollingStock implements IInventor
 		int w = k + kZ;
 
 		if(hY < 0) {
-			Block block = worldObj.getBlock(u - iX, v - 1, w - kZ);
+			Block block = CommonUtil.getBlockAt(worldObj, u - iX, v - 1, w - kZ);
 			if(BlockRail.func_150051_a(block)
 					|| block instanceof BlockTCRail
 					|| block instanceof BlockTCRailGag) {
@@ -946,7 +947,7 @@ public class EntityTracksBuilder extends EntityRollingStock implements IInventor
 				hY++;
 			}
 		}else if(hY > 0) {
-			Block block = worldObj.getBlock(u - iX, v, w - kZ);
+			Block block = CommonUtil.getBlockAt(worldObj, u - iX, v, w - kZ);
 			if(BlockRail.func_150051_a(block)
 					|| block instanceof BlockTCRail
 					|| block instanceof BlockTCRailGag) {
@@ -993,7 +994,7 @@ public class EntityTracksBuilder extends EntityRollingStock implements IInventor
 		success &= replaceBlockAt(u, v - 1, w, this.slotId_UnderBlock);
 
 		// check if underBlock will fall before placing rail
-		Block underBlock = worldObj.getBlock(u, v-1, w);
+		Block underBlock = CommonUtil.getBlockAt(worldObj, u, v-1, w);
 
 		if(underBlock instanceof BlockFalling && BlockFalling.func_149831_e(worldObj, u, v-2, w)) {
 			this.skipTick = true;

--- a/src/main/java/train/common/entity/rollingStockOld/special/EntityTracksBuilder.java
+++ b/src/main/java/train/common/entity/rollingStockOld/special/EntityTracksBuilder.java
@@ -629,7 +629,7 @@ public class EntityTracksBuilder extends EntityRollingStock implements IInventor
 		if (!FMLCommonHandler.instance().getMinecraftServerInstance().isDedicatedServer() && pos != null && worldObj !=null) {
 			Block block = CommonUtil.getBlockAt(worldObj, (int) pos.xCoord, (int) pos.yCoord, (int) pos.zCoord);
 			if (miningTickCounter % 8 == 0 && block != null && !worldObj.isRemote && Minecraft.getMinecraft() != null) {
-				this.worldObj.playSound((int) pos.xCoord + 0.5F, (int) pos.yCoord + 0.5F, (int) pos.zCoord + 0.5F, block.stepSound.getBreakSound(), 1.0F, block.stepSound.getPitch() * 0.5F, true);
+				CommonUtil.playSound(this.worldObj, (int) pos.xCoord + 0.5F, (int) pos.yCoord + 0.5F, (int) pos.zCoord + 0.5F, block.stepSound.getBreakSound(), 1.0F, block.stepSound.getPitch() * 0.5F, 0);
 			}
 			if (miningTickCounter % 8 == 0 && block_index != 0 && block != null && FMLClientHandler.instance().getClient() != null ) {
 				FMLClientHandler.instance().getClient().effectRenderer.addBlockHitEffects((int) pos.xCoord, (int) pos.yCoord, (int) pos.zCoord, block_index < 4 ? getSideFromYaw() : (block_index < 6 ? 1 : 0));

--- a/src/main/java/train/common/entity/rollingStockOld/steam/EntityLocoSteamSnowPlow.java
+++ b/src/main/java/train/common/entity/rollingStockOld/steam/EntityLocoSteamSnowPlow.java
@@ -14,7 +14,6 @@ import train.common.Traincraft;
 import train.common.api.LiquidManager;
 import train.common.api.SteamTrain;
 import train.common.core.FakePlayer;
-import train.common.core.util.TraincraftUtil;
 import train.common.library.GuiIDs;
 
 import java.util.Random;
@@ -55,7 +54,7 @@ public class EntityLocoSteamSnowPlow extends SteamTrain {
 		if (fakePlayer == null){
 			 fakePlayer = new FakePlayer(worldObj);
 		}
-		rotation = MathHelper.floor_float(TraincraftUtil.atan2degreesf(
+		rotation = MathHelper.floor_float(CommonUtil.atan2degreesf(
 				bogieFront.posZ - bogieBack.posZ,
 				bogieFront.posX - bogieBack.posX));
 

--- a/src/main/java/train/common/entity/rollingStockOld/steam/EntityLocoSteamSnowPlow.java
+++ b/src/main/java/train/common/entity/rollingStockOld/steam/EntityLocoSteamSnowPlow.java
@@ -1,5 +1,6 @@
 package train.common.entity.rollingStockOld.steam;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.item.EntityMinecart;
@@ -43,7 +44,7 @@ public class EntityLocoSteamSnowPlow extends SteamTrain {
 	private FakePlayer fakePlayer = null;
 	private int rotation =0;
 
-	private static final float radianF = (float) Math.PI / 180.0f;
+	private static final float radianF = CommonUtil.radianF;
 	@Override
 	public void onUpdate() {
 		super.onUpdate();
@@ -85,12 +86,12 @@ public class EntityLocoSteamSnowPlow extends SteamTrain {
 	}
 
 	private static void mineSnow(World worldObj, double[] point, ItemStack[] cargoItems, FakePlayer fakePlayer){
-		Block b = worldObj.getBlock(MathHelper.floor_double(point[0]),MathHelper.floor_double(point[1]),MathHelper.floor_double(point[2]));
-		int blockMeta = worldObj.getBlockMetadata(MathHelper.floor_double(point[0]), MathHelper.floor_double(point[1]),
-				MathHelper.floor_double(point[2]));
+		Block b = CommonUtil.getBlockAt(worldObj, CommonUtil.floorDouble(point[0]),CommonUtil.floorDouble(point[1]),CommonUtil.floorDouble(point[2]));
+		int blockMeta = CommonUtil.getBlockFacing(worldObj, CommonUtil.floorDouble(point[0]), CommonUtil.floorDouble(point[1]),
+				CommonUtil.floorDouble(point[2]));
 
 		if((b == Blocks.snow || b == Blocks.snow_layer) && b.canHarvestBlock(fakePlayer, blockMeta)){
-			worldObj.setBlockToAir(MathHelper.floor_double(point[0]),MathHelper.floor_double(point[1]),MathHelper.floor_double(point[2]));
+			worldObj.setBlockToAir(CommonUtil.floorDouble(point[0]),CommonUtil.floorDouble(point[1]),CommonUtil.floorDouble(point[2]));
 			int snowballs = new Random().nextInt(9);
 			for(int i=2; i<cargoItems.length && snowballs>0; i++){
 				if (cargoItems[i] == null){

--- a/src/main/java/train/common/entity/zeppelin/AbstractZeppelin.java
+++ b/src/main/java/train/common/entity/zeppelin/AbstractZeppelin.java
@@ -203,7 +203,7 @@ public abstract class AbstractZeppelin extends Entity implements IInventory {
 						if(this.zeppInvent[t]!=null && this.zeppInvent[t].getItem()!=null && this.zeppInvent[t].getItem() == Item.getItemFromBlock(Blocks.tnt)){
 							EntityTNTPrimed entitytntprimed = new EntityTNTPrimed(this.worldObj, (double) ((float) posX), (double) ((float) posY -1F), (double) ((float) posZ), (EntityLivingBase) this.riddenByEntity);
 							this.worldObj.spawnEntityInWorld(entitytntprimed);
-							this.worldObj.playSoundAtEntity(entitytntprimed, "random.fuse", 1.0F, 1.0F);
+							CommonUtil.playSound(entitytntprimed, "random.fuse", 1.0F, 1.0F);
 							bombTimer=100;
 							if(--this.zeppInvent[t].stackSize==0)this.zeppInvent[t]=null;
 							return;

--- a/src/main/java/train/common/entity/zeppelin/AbstractZeppelin.java
+++ b/src/main/java/train/common/entity/zeppelin/AbstractZeppelin.java
@@ -485,7 +485,7 @@ public abstract class AbstractZeppelin extends Entity implements IInventory {
 		double div10 = this.prevPosZ - this.posZ;
 
 		if ((div11 * div11) + (div10 * div10) > 0.001D) {
-			rot = ((float) (Math.atan2(div10, div11) * 180.0D / Math.PI));
+			rot = CommonUtil.atan2degreesf(div10, div11);
 		}
 
 		double d12 = MathHelper.wrapAngleTo180_double(rot - this.rotationYaw);

--- a/src/main/java/train/common/entity/zeppelin/AbstractZeppelin.java
+++ b/src/main/java/train/common/entity/zeppelin/AbstractZeppelin.java
@@ -2,6 +2,7 @@ package train.common.entity.zeppelin;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
@@ -413,8 +414,8 @@ public abstract class AbstractZeppelin extends Entity implements IInventory {
 			d13 = ((EntityLivingBase) this.riddenByEntity).moveForward;
 
 			if (d13 > 0.0D) {
-				d5 = -Math.sin(this.riddenByEntity.rotationYaw * (float) Math.PI / 180.0F);
-				d11 = Math.cos(this.riddenByEntity.rotationYaw * (float) Math.PI / 180.0F);
+				d5 = -Math.sin(this.riddenByEntity.rotationYaw * CommonUtil.radianF);
+				d11 = Math.cos(this.riddenByEntity.rotationYaw * CommonUtil.radianF);
 				this.motionX += d5 * speedMultiplier * 0.05000000074505806D;
 				this.motionZ += d11 * speedMultiplier * 0.05000000074505806D;
 			}

--- a/src/main/java/train/common/items/ItemMetroMadridPole.java
+++ b/src/main/java/train/common/items/ItemMetroMadridPole.java
@@ -1,5 +1,6 @@
 package train.common.items;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
@@ -19,7 +20,7 @@ public class ItemMetroMadridPole extends Item {
 
     @Override
     public boolean onItemUse(ItemStack itemstack, EntityPlayer entityplayer, World world, int i, int j, int k, int l, float par8, float par9, float par10) {
-        Block i1 = world.getBlock(i, j, k);
+        Block i1 = CommonUtil.getBlockAt(world, i, j, k);
         if (i1 == Blocks.snow) {
             l = 0;
         }
@@ -52,7 +53,7 @@ public class ItemMetroMadridPole extends Item {
 
         Block block = spawnID;
         if (world.setBlockMetadataWithNotify(i, j, k, Block.getIdFromBlock(spawnID), 0)) {
-            if (world.getBlock(i, j, k) == spawnID) {
+            if (CommonUtil.getBlockAt(world, i, j, k) == spawnID) {
                 spawnID.onBlockPlacedBy(world, i, j, k, entityplayer, new ItemStack(spawnID));
             }
             itemstack.stackSize--;

--- a/src/main/java/train/common/items/ItemOverheadLines.java
+++ b/src/main/java/train/common/items/ItemOverheadLines.java
@@ -1,5 +1,6 @@
 package train.common.items;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
@@ -19,7 +20,7 @@ public class ItemOverheadLines extends Item {
 
 	@Override
 	public boolean onItemUse(ItemStack itemstack, EntityPlayer entityplayer, World world, int i, int j, int k, int l, float par8, float par9, float par10) {
-		Block i1 = world.getBlock(i, j, k);
+		Block i1 = CommonUtil.getBlockAt(world, i, j, k);
 		if (i1 == Blocks.snow) {
 			l = 0;
 		}
@@ -52,7 +53,7 @@ public class ItemOverheadLines extends Item {
 
 		Block block = spawnID;
 		if (world.setBlockMetadataWithNotify(i, j, k, Block.getIdFromBlock(spawnID), 0)) {
-			if (world.getBlock(i, j, k) == spawnID) {
+			if (CommonUtil.getBlockAt(world, i, j, k) == spawnID) {
 				spawnID.onBlockPlacedBy(world, i, j, k, entityplayer, new ItemStack(spawnID));
 			}
 			world.playSoundEffect((float) i + 0.5F, (float) j + 0.5F, (float) k + 0.5F, block.stepSound.getStepResourcePath(), (block.stepSound.getVolume() + 1.0F) / 2.0F, block.stepSound.getPitch() * 0.8F);

--- a/src/main/java/train/common/items/ItemRollingStock.java
+++ b/src/main/java/train/common/items/ItemRollingStock.java
@@ -20,13 +20,11 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
-import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import train.common.Traincraft;
 import train.common.api.*;
 import train.common.core.handlers.ConfigHandler;
-import train.common.core.util.TraincraftUtil;
 import train.common.entity.rollingStockOld.special.EntityTracksBuilder;
 import train.common.library.BlockIDs;
 import train.common.library.EnumTracks;
@@ -293,7 +291,7 @@ public class ItemRollingStock extends ItemMinecart implements IMinecart, IMineca
 			par2EntityPlayer.addChatMessage(new ChatComponentText("Place me on a straight piece of track !"));
 			return false;
 		}
-		else if (TraincraftUtil.isRailBlockAt(par3World, par4, par5, par6) && (meta < 2 || meta > 5)) {
+		else if (CommonUtil.isRailBlockAt(par3World, par4, par5, par6) && (meta < 2 || meta > 5)) {
 			this.placeCart(par2EntityPlayer, par1ItemStack, par3World, par4, par5, par6);
 			return true;
 		}

--- a/src/main/java/train/common/items/ItemRollingStock.java
+++ b/src/main/java/train/common/items/ItemRollingStock.java
@@ -216,7 +216,7 @@ public class ItemRollingStock extends ItemMinecart implements IMinecart, IMineca
 
 	@Override
 	public boolean onItemUse(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, World par3World, int par4, int par5, int par6, int par7, float par8, float par9, float par10) {
-		int meta = par3World.getBlockMetadata(par4, par5, par6);
+		int meta = CommonUtil.getBlockFacing(par3World, par4, par5, par6);
 		TileEntity tileentity = par3World.getTileEntity(par4, par5, par6);
 		//System.out.println(meta);
 		if (par3World.isRemote) {
@@ -328,9 +328,9 @@ public class ItemRollingStock extends ItemMinecart implements IMinecart, IMineca
 		for (int check = 0; check <= trackLength ; check++){
 
 
-			if (!(world.getBlock((int) (i - ((rollingstock.rotationPoints()[1] + check) * xDir)), j, (int) (k - ((rollingstock.rotationPoints()[1] + check) * zDir)) ) == BlockIDs.tcRail.block
-				|| !(world.getBlock((int) (i - ((rollingstock.rotationPoints()[1] + check) * xDir)), j, (int) (k - ((rollingstock.rotationPoints()[1] + check) * zDir)) ) == BlockIDs.tcRailGag.block)
-				|| !(BlockRailBase.func_150051_a(world.getBlock((int) (i - ((rollingstock.rotationPoints()[1] + check) * xDir)), j, (int) (k - ((rollingstock.rotationPoints()[1] + check) * zDir)) ))))){
+			if (!(CommonUtil.getBlockAt(world, (int) (i - ((rollingstock.rotationPoints()[1] + check) * xDir)), j, (int) (k - ((rollingstock.rotationPoints()[1] + check) * zDir)) ) == BlockIDs.tcRail.block
+				|| !(CommonUtil.getBlockAt(world, (int) (i - ((rollingstock.rotationPoints()[1] + check) * xDir)), j, (int) (k - ((rollingstock.rotationPoints()[1] + check) * zDir)) ) == BlockIDs.tcRailGag.block)
+				|| !(BlockRailBase.func_150051_a(CommonUtil.getBlockAt(world, (int) (i - ((rollingstock.rotationPoints()[1] + check) * xDir)), j, (int) (k - ((rollingstock.rotationPoints()[1] + check) * zDir)) ))))){
 
 
 				return false;
@@ -375,14 +375,14 @@ public class ItemRollingStock extends ItemMinecart implements IMinecart, IMineca
 
 				int dir = 0;
 				int meta;
-				if (world.getBlock(i, j, k) instanceof BlockRailBase) {
-					meta = ((BlockRailBase) world.getBlock(i, j, k)).getBasicRailMetadata(world, rollingStock, i, j, k);
+				if (CommonUtil.getBlockAt(world, i, j, k) instanceof BlockRailBase) {
+					meta = ((BlockRailBase) CommonUtil.getBlockAt(world, i, j, k)).getBasicRailMetadata(world, rollingStock, i, j, k);
 				} else {
-					meta = world.getBlockMetadata(i, j, k);
+					meta = CommonUtil.getBlockFacing(world, i, j, k);
 				}
 
 				if (player != null)
-					dir = MathHelper.floor_double((player.rotationYaw * 8F) / 360F + 0.5D) & 7;
+					dir = CommonUtil.floorDouble((player.rotationYaw * 8F) / 360F + 0.5D) & 7;
 				// 0    = 0 = SOUTH
 				// 45   = 1 = SOUTH-WEST
 				// 90   = 2 = WEST
@@ -397,7 +397,7 @@ public class ItemRollingStock extends ItemMinecart implements IMinecart, IMineca
 
 					rollingStock.rotationYaw = (meta == 2 || meta == 0) ? 90 : 0;
 
-					if (world.getBlock(i, j, k) == BlockIDs.tcRail.block || world.getBlock(i, j, k) == BlockIDs.tcRailGag.block) {
+					if (CommonUtil.getBlockAt(world, i, j, k) == BlockIDs.tcRail.block || CommonUtil.getBlockAt(world, i, j, k) == BlockIDs.tcRailGag.block) {
 
 						if (meta == 0 || meta == 2) {
 							//rollingStock.rotationYaw = -90; // LEFT
@@ -422,7 +422,7 @@ public class ItemRollingStock extends ItemMinecart implements IMinecart, IMineca
 				if (dir == 1) {
 					rollingStock.rotationYaw = (meta == 2 || meta == 0) ? 90 : 0;
 
-					if (world.getBlock(i, j, k) == BlockIDs.tcRail.block || world.getBlock(i, j, k) == BlockIDs.tcRailGag.block) {
+					if (CommonUtil.getBlockAt(world, i, j, k) == BlockIDs.tcRail.block || CommonUtil.getBlockAt(world, i, j, k) == BlockIDs.tcRailGag.block) {
 						if (meta == 6 || meta == 4) {
 							rollingStock.rotationYaw = 135; // LEFT
 						} else if (meta == 2 || meta == 0) {
@@ -440,7 +440,7 @@ public class ItemRollingStock extends ItemMinecart implements IMinecart, IMineca
 
 				if (dir == 2) {
 					rollingStock.rotationYaw = (meta == 1 || meta == 3) ? 180 : 90;
-					if (world.getBlock(i, j, k) == BlockIDs.tcRail.block || world.getBlock(i, j, k) == BlockIDs.tcRailGag.block) {
+					if (CommonUtil.getBlockAt(world, i, j, k) == BlockIDs.tcRail.block || CommonUtil.getBlockAt(world, i, j, k) == BlockIDs.tcRailGag.block) {
 						if (meta == 1 || meta == 3){
 							rollingStock.rotationYaw = 180; // LEFT
 						}
@@ -463,7 +463,7 @@ public class ItemRollingStock extends ItemMinecart implements IMinecart, IMineca
 				if (dir == 3) {
 					rollingStock.rotationYaw = (meta == 2 || meta == 0) ? -90 : 180;
 
-					if (world.getBlock(i, j, k) == BlockIDs.tcRail.block || world.getBlock(i, j, k) == BlockIDs.tcRailGag.block) {
+					if (CommonUtil.getBlockAt(world, i, j, k) == BlockIDs.tcRail.block || CommonUtil.getBlockAt(world, i, j, k) == BlockIDs.tcRailGag.block) {
 						if (meta == 5 || meta == 7) {
 							rollingStock.rotationYaw = -135; // LEFT
 						}
@@ -485,7 +485,7 @@ public class ItemRollingStock extends ItemMinecart implements IMinecart, IMineca
 				if (dir == 4) {
 					rollingStock.rotationYaw = (meta == 2 || meta == 0) ? -90 : 180;
 
-					if (world.getBlock(i, j, k) == BlockIDs.tcRail.block || world.getBlock(i, j, k) == BlockIDs.tcRailGag.block) {
+					if (CommonUtil.getBlockAt(world, i, j, k) == BlockIDs.tcRail.block || CommonUtil.getBlockAt(world, i, j, k) == BlockIDs.tcRailGag.block) {
 						if (meta == 0 || meta == 2) {
 							rollingStock.rotationYaw = -90; // RIGHT
 						}
@@ -510,7 +510,7 @@ public class ItemRollingStock extends ItemMinecart implements IMinecart, IMineca
 				if (dir == 5) {
 					rollingStock.rotationYaw = (meta == 2 || meta == 0) ? -90 : 0;
 
-					if (world.getBlock(i, j, k) == BlockIDs.tcRail.block || world.getBlock(i, j, k) == BlockIDs.tcRailGag.block) {
+					if (CommonUtil.getBlockAt(world, i, j, k) == BlockIDs.tcRail.block || CommonUtil.getBlockAt(world, i, j, k) == BlockIDs.tcRailGag.block) {
 						if (meta == 6 || meta == 4) {
 							rollingStock.rotationYaw = -45; // LEFT
 						}
@@ -532,7 +532,7 @@ public class ItemRollingStock extends ItemMinecart implements IMinecart, IMineca
 				if (dir == 6) {
 					rollingStock.rotationYaw = (meta == 0 || meta == 2) ? -90 : 0;
 				
-					if (world.getBlock(i, j, k) == BlockIDs.tcRail.block || world.getBlock(i, j, k) == BlockIDs.tcRailGag.block) {
+					if (CommonUtil.getBlockAt(world, i, j, k) == BlockIDs.tcRail.block || CommonUtil.getBlockAt(world, i, j, k) == BlockIDs.tcRailGag.block) {
 						if (meta == 1 || meta == 3) {
 							rollingStock.rotationYaw = 0;
 						}
@@ -553,7 +553,7 @@ public class ItemRollingStock extends ItemMinecart implements IMinecart, IMineca
 				if (dir == 7) {
 					rollingStock.rotationYaw = (meta == 0 || meta == 2) ? 90 : 0;
 
-					if (world.getBlock(i, j, k) == BlockIDs.tcRail.block || world.getBlock(i, j, k) == BlockIDs.tcRailGag.block) {
+					if (CommonUtil.getBlockAt(world, i, j, k) == BlockIDs.tcRail.block || CommonUtil.getBlockAt(world, i, j, k) == BlockIDs.tcRailGag.block) {
 						if (meta == 5 || meta == 7) {
 							rollingStock.rotationYaw = 45; // LEFT
 						}

--- a/src/main/java/train/common/items/ItemSignal.java
+++ b/src/main/java/train/common/items/ItemSignal.java
@@ -1,5 +1,6 @@
 package train.common.items;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
@@ -22,7 +23,7 @@ public class ItemSignal extends Item { // implements IBoxable TODO when IC2
 	}
 
 	public boolean onItemUse(ItemStack itemstack, EntityPlayer entityplayer, World world, int i, int j, int k, int l) {
-		Block i1 = world.getBlock(i, j, k);
+		Block i1 = CommonUtil.getBlockAt(world, i, j, k);
 		if (i1 == Blocks.snow) {
 			l = 0;
 		}
@@ -55,7 +56,7 @@ public class ItemSignal extends Item { // implements IBoxable TODO when IC2
 
 		Block block = spawnID;
 		if (world.setBlockMetadataWithNotify(i, j, k, Block.getIdFromBlock(spawnID), 0)) {
-			if (world.getBlock(i, j, k) == spawnID) {
+			if (CommonUtil.getBlockAt(world, i, j, k) == spawnID) {
 				spawnID.onBlockPlacedBy(world, i, j, k, entityplayer, new ItemStack(spawnID));
 			}
 			world.playSoundEffect((float) i + 0.5F, (float) j + 0.5F, (float) k + 0.5F, block.stepSound.getStepResourcePath(), (block.stepSound.getVolume() + 1.0F) / 2.0F, block.stepSound.getPitch() * 0.8F);

--- a/src/main/java/train/common/items/ItemTCRail.java
+++ b/src/main/java/train/common/items/ItemTCRail.java
@@ -2,6 +2,7 @@ package train.common.items;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockFlower;
 import net.minecraft.block.BlockMushroom;
@@ -54,7 +55,7 @@ public class ItemTCRail extends ItemPart {
     }
 
     private boolean canPlaceTrack(EntityPlayer player, World world, int x, int y, int z) {
-        Block l1 = world.getBlock(x, y - 1, z);
+        Block l1 = CommonUtil.getBlockAt(world, x, y - 1, z);
 
         if (player != null && (!player.canPlayerEdit(x, y - 1, z, 0, player.getCurrentEquippedItem()) ||
                 !player.canPlayerEdit(x, y, z, 0, player.getCurrentEquippedItem()))
@@ -62,7 +63,7 @@ public class ItemTCRail extends ItemPart {
             return false;
         }
 
-        if(ConfigHandler.TRACK_OVERLAP && world.getBlock(x,y,z) instanceof BlockTCRailGag){
+        if(ConfigHandler.TRACK_OVERLAP && CommonUtil.getBlockAt(world, x,y,z) instanceof BlockTCRailGag){
             return true;
         }
 
@@ -70,7 +71,7 @@ public class ItemTCRail extends ItemPart {
     }
 
     private boolean canPlaceRootTrack(EntityPlayer player, World world, int x, int y, int z) {
-        Block l1 = world.getBlock(x, y - 1, z);
+        Block l1 = CommonUtil.getBlockAt(world, x, y - 1, z);
 
         if (player != null && (!player.canPlayerEdit(x, y - 1, z, 0, player.getCurrentEquippedItem()) ||
                 !player.canPlayerEdit(x, y, z, 0, player.getCurrentEquippedItem()))
@@ -78,7 +79,7 @@ public class ItemTCRail extends ItemPart {
             return false;
         }
 
-        if(world.getBlock(x,y,z) instanceof BlockTCRailGag){
+        if(CommonUtil.getBlockAt(world, x,y,z) instanceof BlockTCRailGag){
             return false;
         }
 
@@ -86,7 +87,7 @@ public class ItemTCRail extends ItemPart {
     }
 
     private boolean canBeReplaced(World world, int x, int y, int z) {
-        Block block = world.getBlock(x, y, z);
+        Block block = CommonUtil.getBlockAt(world, x, y, z);
         return block == null || block.isReplaceable(world, x, y, z) || block instanceof BlockFlower
                 || block == Blocks.double_plant || block instanceof BlockMushroom;
     }
@@ -208,10 +209,10 @@ public class ItemTCRail extends ItemPart {
         tcRail.idDrop = idDrop;
         tcRail.slopeAngle = slopeAngle;
         tcRail.slopeLength = slopeLength;
-        Block block = world.getBlock(x, y, z);
+        Block block = CommonUtil.getBlockAt(world, x, y, z);
         int blockID = Block.getIdFromBlock(block);
         tcRail.setBallastMaterial(blockID);
-        tcRail.ballastMetadata = world.getBlockMetadata(x, y, z);
+        tcRail.ballastMetadata = CommonUtil.getBlockFacing(world, x, y, z);
         /** Gag rails containing reference to first turn rail */
         for (int gag = 1; gag <= posX.length - 1; gag++) {
             placeTrack(world, posX[gag], y + 1, posZ[gag], BlockIDs.tcRailGag.block, 0);
@@ -468,10 +469,10 @@ public class ItemTCRail extends ItemPart {
         y = getPlacementHeight(world, x, y, z);
 
         ItemTCRail item = (ItemTCRail) itemStack.getItem();
-        if (world.getBlock(x, y, z) == TCBlocks.bridgePillar && item.getTrackType().getLabel().contains("DYNAMIC")) {
+        if (CommonUtil.getBlockAt(world, x, y, z) == TCBlocks.bridgePillar && item.getTrackType().getLabel().contains("DYNAMIC")) {
             return false;
         }
-        int facing0 = MathHelper.floor_double(player.rotationYaw * 4.0F / 360.0F + 0.5D) & 3;
+        int facing0 = CommonUtil.floorDouble(player.rotationYaw * 4.0F / 360.0F + 0.5D) & 3;
         Vector2f dir0 = ItemTCRail.getDirectionVector(facing0);
 
         float yaw = MathHelper.wrapAngleTo180_float(player.rotationYaw);
@@ -541,10 +542,10 @@ public class ItemTCRail extends ItemPart {
             int[] curveZArray2;
 
             if (type.getRailType() == RailTypes.DIAGONAL) {
-                l = MathHelper.floor_double((player != null ? player.rotationYaw : par10) * 4.0F / 360.0F) & 3;
+                l = CommonUtil.floorDouble((player != null ? player.rotationYaw : par10) * 4.0F / 360.0F) & 3;
                 l += 4;
             } else {
-                l = MathHelper.floor_double((player != null ? player.rotationYaw : par10) * 4.0F / 360.0F + 0.5D) & 3;
+                l = CommonUtil.floorDouble((player != null ? player.rotationYaw : par10) * 4.0F / 360.0F + 0.5D) & 3;
             }
 
 
@@ -1789,7 +1790,7 @@ public class ItemTCRail extends ItemPart {
                     if (!canPlaceTrack(player, world, x, y + 1, z)) {
                         return false;
                     }
-                    if (type.getLabel().contains("DYNAMIC") && world.getBlock(x, y, z) == TCBlocks.bridgePillar) {
+                    if (type.getLabel().contains("DYNAMIC") && CommonUtil.getBlockAt(world, x, y, z) == TCBlocks.bridgePillar) {
                         return false;
                     }
 
@@ -1855,10 +1856,10 @@ public class ItemTCRail extends ItemPart {
                     tcRail.slopeAngle = slopeAngle;
                     tcRail.slopeLength = gagEnd + 1;
 
-                    Block block = world.getBlock(x, y, z);
+                    Block block = CommonUtil.getBlockAt(world, x, y, z);
                     int blockID = Block.getIdFromBlock(block);
                     tcRail.setBallastMaterial(blockID);
-                    tcRail.ballastMetadata = world.getBlockMetadata(x, y, z);
+                    tcRail.ballastMetadata = CommonUtil.getBlockFacing(world, x, y, z);
 
 
                     for (int i2 = 1; i2 <= gagEnd; i2++) {
@@ -2497,10 +2498,10 @@ public class ItemTCRail extends ItemPart {
         tcRail.idDrop = this.type.getItem().item;
 
         if (type == EnumTracks.SMALL_ROAD_CROSSING_DYNAMIC){
-            Block block = world.getBlock(x, y, z);
+            Block block = CommonUtil.getBlockAt(world, x, y, z);
             int blockID = Block.getIdFromBlock(block);
             tcRail.setBallastMaterial(blockID);
-            tcRail.ballastMetadata = world.getBlockMetadata(x, y, z);
+            tcRail.ballastMetadata = CommonUtil.getBlockFacing(world, x, y, z);
         }
 
 
@@ -4997,9 +4998,9 @@ public class ItemTCRail extends ItemPart {
      * Drop the previous block before placing the track.
      */
     private void placeTrack(World world, int x, int y, int z, Block block, int metadata) {
-        Block removed = world.getBlock(x, y, z);
+        Block removed = CommonUtil.getBlockAt(world, x, y, z);
         if (removed != null && !(removed instanceof BlockTCRailGag) && !(block instanceof BlockTCRail)) {
-            removed.dropBlockAsItem(world, x, y, z, world.getBlockMetadata(x, y, z), 0);
+            removed.dropBlockAsItem(world, x, y, z, CommonUtil.getBlockFacing(world, x, y, z), 0);
         }
         if(!ConfigHandler.TRACK_OVERLAP || !(removed  instanceof BlockTCRail || removed instanceof BlockTCRailGag)){
             world.setBlock(x, y, z, block, metadata, 3);

--- a/src/main/java/train/common/items/ItemTrackDebugger.java
+++ b/src/main/java/train/common/items/ItemTrackDebugger.java
@@ -2,6 +2,7 @@ package train.common.items;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockRailBase;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -39,7 +40,7 @@ public class ItemTrackDebugger extends Item {
                 return false;
             }
 
-            Block block = world.getBlock(x, y, z);
+            Block block = CommonUtil.getBlockAt(world, x, y, z);
             if (block == BlockIDs.tcRail.block){
                 TileTCRail tile = (TileTCRail) world.getTileEntity(x, y, z);
 

--- a/src/main/java/train/common/items/ItemWaterTankBuckets.java
+++ b/src/main/java/train/common/items/ItemWaterTankBuckets.java
@@ -1,5 +1,6 @@
 package train.common.items;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemBucket;
@@ -20,12 +21,12 @@ public class ItemWaterTankBuckets extends ItemBucket { // implements IBucketHand
 	}
 
 	public ItemStack fillCustomBucket(World w, int i, int j, int k) {
-		if (w.getBlock(i, j, k) == Blocks.water || w.getBlock(i, j, k) == Blocks.water) {
+		if (CommonUtil.getBlockAt(w, i, j, k) == Blocks.water || CommonUtil.getBlockAt(w, i, j, k) == Blocks.water) {
 			w.setBlockMetadataWithNotify(i, j, k, 0, 0);
 			return new ItemStack(this);
 		}
 
-		if (w.getBlock(i, j, k) == Blocks.flowing_water || w.getBlock(i, j, k) == Blocks.flowing_water) {
+		if (CommonUtil.getBlockAt(w, i, j, k) == Blocks.flowing_water || CommonUtil.getBlockAt(w, i, j, k) == Blocks.flowing_water) {
 			w.setBlockMetadataWithNotify(i, j, k, 0, 0);
 			return new ItemStack(this);
 		}

--- a/src/main/java/train/common/items/ItemWhistle.java
+++ b/src/main/java/train/common/items/ItemWhistle.java
@@ -2,6 +2,7 @@ package train.common.items;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
@@ -35,7 +36,7 @@ public class ItemWhistle extends Item {
 
     @Override
     public ItemStack onItemRightClick(ItemStack p_77659_1_, World p_77659_2_, EntityPlayer p_77659_3_) {
-        p_77659_2_.playSoundAtEntity(p_77659_3_, Info.resourceLocation + ":" + "whistle", 1F, 1.0F);
+        CommonUtil.playSound(p_77659_3_, Info.resourceLocation + ":" + "whistle", 1F, 1.0F);
         return super.onItemRightClick(p_77659_1_, p_77659_2_, p_77659_3_);
 
     }

--- a/src/main/java/train/common/items/ItemWrench.java
+++ b/src/main/java/train/common/items/ItemWrench.java
@@ -3,6 +3,7 @@ package train.common.items;
 import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -23,7 +24,7 @@ public class ItemWrench extends ItemPart implements buildcraft.api.tools.IToolWr
 
 	@Override
 	public boolean onItemUseFirst(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ) {
-		Block blockId = world.getBlock(x, y, z);
+		Block blockId = CommonUtil.getBlockAt(world, x, y, z);
 		if (blockId.rotateBlock(world, x, y, z, ForgeDirection.getOrientation(side))) {
 			player.swingItem();
 			return !world.isRemote;

--- a/src/main/java/train/common/library/TraincraftRegistry.java
+++ b/src/main/java/train/common/library/TraincraftRegistry.java
@@ -9,6 +9,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import ebf.tim.api.SkinRegistry;
 import ebf.tim.render.CustomItemModel;
+import ebf.tim.utility.CommonUtil;
 import ebf.tim.utility.DebugUtil;
 import ebf.tim.utility.OreGen;
 import fexcraft.tmt.slim.ModelBase;
@@ -324,7 +325,7 @@ public class TraincraftRegistry {
         if (oreDictionaryName != null) {
             OreDictionary.registerOre(oreDictionaryName, block);
         }
-        if (DebugUtil.dev && Traincraft.proxy.isClient() && block.getUnlocalizedName().equals(StatCollector.translateToLocal(block.getUnlocalizedName() +".name"))) {
+        if (DebugUtil.dev && Traincraft.proxy.isClient() && block.getUnlocalizedName().equals(CommonUtil.translate(block.getUnlocalizedName() +".name"))) {
             DebugUtil.println("Block missing lang entry: " + block.getUnlocalizedName());
         }
         if (block instanceof ITileEntityProvider) {
@@ -382,7 +383,7 @@ public class TraincraftRegistry {
         if (oreDictionaryName != null) {
             OreDictionary.registerOre(oreDictionaryName, itm);
         }
-        if (DebugUtil.dev && Traincraft.proxy != null && Traincraft.proxy.isClient() && itm.getUnlocalizedName().equals(StatCollector.translateToLocal(itm.getUnlocalizedName()+".name"))) {
+        if (DebugUtil.dev && Traincraft.proxy != null && Traincraft.proxy.isClient() && itm.getUnlocalizedName().equals(CommonUtil.translate(itm.getUnlocalizedName()+".name"))) {
             DebugUtil.println("Item missing lang entry: " + itm.getUnlocalizedName());
         }
         if (Traincraft.proxy.isClient() && itemRender != null) {

--- a/src/main/java/train/common/tile/TileEntityDistil.java
+++ b/src/main/java/train/common/tile/TileEntityDistil.java
@@ -166,7 +166,7 @@ public class TileEntityDistil extends TileTraincraft implements IFluidHandler {
 			else {
 				flag1 = false;
 				BlockDistil.updateDistilBlockState(distilBurnTime > 0, worldObj, xCoord, yCoord, zCoord);
-				this.worldObj.markBlockForUpdate(this.xCoord, this.yCoord, this.zCoord);
+				CommonUtil.markBlockForUpdate(this.worldObj, this.xCoord, this.yCoord, this.zCoord);
 			}
 
 			if (slots[2] != null) {
@@ -200,7 +200,7 @@ public class TileEntityDistil extends TileTraincraft implements IFluidHandler {
 						flag1 = true;
 
 						this.markDirty();
-						this.worldObj.markBlockForUpdate(this.xCoord, this.yCoord, this.zCoord);
+						CommonUtil.markBlockForUpdate(this.worldObj, this.xCoord, this.yCoord, this.zCoord);
 					}
 				}
 			}
@@ -219,7 +219,7 @@ public class TileEntityDistil extends TileTraincraft implements IFluidHandler {
 			}
 			if (updateTicks % 8 == 0){
 				this.markDirty();
-				this.worldObj.markBlockForUpdate(this.xCoord, this.yCoord, this.zCoord);
+				CommonUtil.markBlockForUpdate(this.worldObj, this.xCoord, this.yCoord, this.zCoord);
 			}
 			if (distilBurnTime > 0) {
 				distilBurnTime--;
@@ -298,7 +298,7 @@ public class TileEntityDistil extends TileTraincraft implements IFluidHandler {
 			}
 
 			this.markDirty();
-			this.worldObj.markBlockForUpdate(this.xCoord, this.yCoord, this.zCoord);
+			CommonUtil.markBlockForUpdate(this.worldObj, this.xCoord, this.yCoord, this.zCoord);
 		}
 
 		if (slots[0].getItem().hasContainerItem(slots[0])) {

--- a/src/main/java/train/common/tile/TileMFPBWigWag.java
+++ b/src/main/java/train/common/tile/TileMFPBWigWag.java
@@ -1,5 +1,6 @@
 package train.common.tile;
 
+import ebf.tim.utility.CommonUtil;
 import train.common.api.blocks.TileSwitch;
 import train.common.blocks.BlockMFPBWigWag;
 import train.common.library.Info;
@@ -28,7 +29,7 @@ public class TileMFPBWigWag extends TileSwitch {
         if(worldObj.isRemote) {
             if (rotation > 20 || rotation < -20) {
                 flip = !flip;
-                worldObj.playSound(xCoord,yCoord,zCoord,Info.resourceLocation + ":" + "bell",1f,1f,true);
+                CommonUtil.playSound(this, Info.resourceLocation + ":" + "bell", 1f, 1f);
 
             }
             powered = getWorldObj().isBlockIndirectlyGettingPowered(xCoord, yCoord, zCoord);

--- a/src/main/java/train/common/tile/TileMetroMadridPole.java
+++ b/src/main/java/train/common/tile/TileMetroMadridPole.java
@@ -3,6 +3,7 @@ package train.common.tile;
 import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.Packet;
@@ -42,7 +43,7 @@ public class TileMetroMadridPole extends TileEntity {
     }
 
     public void setFacing(ForgeDirection face) {
-        worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+        CommonUtil.markBlockForUpdate(worldObj, xCoord, yCoord, zCoord);
         this.facing = face;
     }
 

--- a/src/main/java/train/common/tile/TileTCRail.java
+++ b/src/main/java/train/common/tile/TileTCRail.java
@@ -80,7 +80,7 @@ public class TileTCRail extends TileEntity {
 	}
 
 	public void setType(String type) {
-		worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+		CommonUtil.markBlockForUpdate(worldObj, xCoord, yCoord, zCoord);
 		this.type = type;
 		for (EnumTracks rail : EnumTracks.values()) {
 			if (rail.getLabel().equals(type)) {
@@ -99,7 +99,7 @@ public class TileTCRail extends TileEntity {
 
 
 	public void setBallastMaterial(int  ballast) {
-		worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+		CommonUtil.markBlockForUpdate(worldObj, xCoord, yCoord, zCoord);
 		this.ballastMaterial = ballast;
 	}
 
@@ -262,7 +262,7 @@ public class TileTCRail extends TileEntity {
 		}
 
 		this.markDirty();
-		this.worldObj.markBlockForUpdate(this.xCoord, this.yCoord, this.zCoord);
+		CommonUtil.markBlockForUpdate(this.worldObj, this.xCoord, this.yCoord, this.zCoord);
 	}
 
 	@Override

--- a/src/main/java/train/common/tile/TileTCRailGag.java
+++ b/src/main/java/train/common/tile/TileTCRailGag.java
@@ -1,6 +1,7 @@
 package train.common.tile;
 
 import cpw.mods.fml.relauncher.Side;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.nbt.NBTTagCompound;
@@ -112,9 +113,9 @@ public class TileTCRailGag extends TileEntity {
 		for(int x : matrixXZ){
 			for(int z : matrixXZ){
 				for(int y : matrixY){
-					if(p_149749_1_.getBlock(xCoord,yCoord,zCoord)instanceof BlockTCRail){
+					if(CommonUtil.getBlockAt(p_149749_1_, xCoord,yCoord,zCoord)instanceof BlockTCRail){
 						p_149749_1_.func_147453_f(p_149749_2_,p_149749_3_,p_149749_4_, Blocks.air);
-						p_149749_1_.markBlockForUpdate(p_149749_2_,p_149749_3_,p_149749_4_);
+						CommonUtil.markBlockForUpdate(p_149749_1_, p_149749_2_,p_149749_3_,p_149749_4_);
 					}
 				}
 			}

--- a/src/main/java/train/common/tile/TileWaterWheel.java
+++ b/src/main/java/train/common/tile/TileWaterWheel.java
@@ -1,6 +1,7 @@
 package train.common.tile;
 
 import cofh.api.energy.IEnergyProvider;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockLiquid;
 import net.minecraft.block.material.Material;
@@ -30,37 +31,37 @@ public class TileWaterWheel extends Energy implements IEnergyProvider {
 
 		if(!worldObj.isRemote) {
 
-			Block blockXP = worldObj.getBlock(xCoord+1, yCoord, zCoord);
-			Block blockXN = worldObj.getBlock(xCoord-1, yCoord, zCoord);
-			Block blockZP = worldObj.getBlock(xCoord, yCoord, zCoord+1);
-			Block blockZN = worldObj.getBlock(xCoord, yCoord, zCoord-1);
-			Block blockTop = worldObj.getBlock(xCoord, yCoord+1, zCoord);
-			Block blockBottom = worldObj.getBlock(xCoord, yCoord-1, zCoord);
+			Block blockXP = CommonUtil.getBlockAt(worldObj, xCoord+1, yCoord, zCoord);
+			Block blockXN = CommonUtil.getBlockAt(worldObj, xCoord-1, yCoord, zCoord);
+			Block blockZP = CommonUtil.getBlockAt(worldObj, xCoord, yCoord, zCoord+1);
+			Block blockZN = CommonUtil.getBlockAt(worldObj, xCoord, yCoord, zCoord-1);
+			Block blockTop = CommonUtil.getBlockAt(worldObj, xCoord, yCoord+1, zCoord);
+			Block blockBottom = CommonUtil.getBlockAt(worldObj, xCoord, yCoord-1, zCoord);
 
 
 			if (blockXP instanceof BlockLiquid && blockXP.getMaterial().isLiquid()
-					&& worldObj.getBlockMetadata(xCoord + 1, yCoord, zCoord) != 0
+					&& CommonUtil.getBlockFacing(worldObj, xCoord + 1, yCoord, zCoord) != 0
 					&& blockXP.getMaterial() != Material.lava) {
 				this.energy.receiveEnergy(5, false);
 				worldObj.setBlockMetadataWithNotify(xCoord, yCoord, zCoord, 2, 2);
 			} else if (blockXN instanceof BlockLiquid && blockXN.getMaterial().isLiquid()
-					&& worldObj.getBlockMetadata(xCoord - 1, yCoord, zCoord) != 0
+					&& CommonUtil.getBlockFacing(worldObj, xCoord - 1, yCoord, zCoord) != 0
 					&& blockXN.getMaterial() != Material.lava) {
 				this.energy.receiveEnergy(5, false);
 				worldObj.setBlockMetadataWithNotify(xCoord, yCoord, zCoord, 0, 2);
 			} else if (blockZN instanceof BlockLiquid && blockZN.getMaterial().isLiquid()
-					&& worldObj.getBlockMetadata(xCoord, yCoord, zCoord - 1) != 0
+					&& CommonUtil.getBlockFacing(worldObj, xCoord, yCoord, zCoord - 1) != 0
 					&& blockZN.getMaterial() != Material.lava) {
 				this.energy.receiveEnergy(5, false);
 				worldObj.setBlockMetadataWithNotify(xCoord, yCoord, zCoord, 1, 2);
 			} else if (blockZP instanceof BlockLiquid && blockZP.getMaterial().isLiquid()
-					&& worldObj.getBlockMetadata(xCoord, yCoord, zCoord + 1) != 0
+					&& CommonUtil.getBlockFacing(worldObj, xCoord, yCoord, zCoord + 1) != 0
 					&& blockZP.getMaterial() != Material.lava) {
 				this.energy.receiveEnergy(5, false);
 				worldObj.setBlockMetadataWithNotify(xCoord, yCoord, zCoord, 3, 2);
-			}else if(blockTop instanceof BlockLiquid && blockTop.getMaterial().isLiquid()&&worldObj.getBlockMetadata(xCoord, yCoord+1, zCoord)!= 0 && blockTop.getMaterial() != Material.lava){
+			}else if(blockTop instanceof BlockLiquid && blockTop.getMaterial().isLiquid()&&CommonUtil.getBlockFacing(worldObj, xCoord, yCoord+1, zCoord)!= 0 && blockTop.getMaterial() != Material.lava){
 				this.energy.receiveEnergy(5, false);
-			}else if(blockBottom instanceof BlockLiquid && blockBottom.getMaterial().isLiquid() &&worldObj.getBlockMetadata(xCoord, yCoord-1, zCoord)!= 0 && blockBottom.getMaterial() != Material.lava){
+			}else if(blockBottom instanceof BlockLiquid && blockBottom.getMaterial().isLiquid() &&CommonUtil.getBlockFacing(worldObj, xCoord, yCoord-1, zCoord)!= 0 && blockBottom.getMaterial() != Material.lava){
 				this.energy.receiveEnergy(5, false);
 			} else {
 				setFacing(-1);

--- a/src/main/java/train/common/tile/TileWindMill.java
+++ b/src/main/java/train/common/tile/TileWindMill.java
@@ -2,6 +2,7 @@ package train.common.tile;
 
 
 import cofh.api.energy.IEnergyProvider;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.Item;
@@ -56,7 +57,7 @@ public class TileWindMill extends Energy implements IEnergyProvider {
 		if (!worldObj.isRemote) {
 			if (updateTicks % 20 == 0) {
 				if (!this.worldObj.isAirBlock(this.xCoord, this.yCoord + 1, this.zCoord)) {
-					Block block = this.worldObj.getBlock(this.xCoord, this.yCoord + 1, this.zCoord);
+					Block block = CommonUtil.getBlockAt(this.worldObj, this.xCoord, this.yCoord + 1, this.zCoord);
 					if (block != null) {
 						EntityItem entityitem = new EntityItem(worldObj, this.xCoord, this.yCoord + 1, this.zCoord, new ItemStack(Item.getItemFromBlock(BlockIDs.windMill.block),1));
 						float f3 = 0.05F;

--- a/src/main/java/train/common/tile/switchStand/TileAutoSwitchStand.java
+++ b/src/main/java/train/common/tile/switchStand/TileAutoSwitchStand.java
@@ -2,6 +2,7 @@ package train.common.tile.switchStand;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.Item;
@@ -33,7 +34,7 @@ public class TileAutoSwitchStand extends TileSwitch {
         if (!worldObj.isRemote) {
             if (updateTicks % 20 == 0) {
                 if (!this.worldObj.isAirBlock(this.xCoord, this.yCoord + 1, this.zCoord)) {
-                    Block block = this.worldObj.getBlock(this.xCoord, this.yCoord + 1, this.zCoord);
+                    Block block = CommonUtil.getBlockAt(this.worldObj, this.xCoord, this.yCoord + 1, this.zCoord);
                     if (block != null) {
                         EntityItem entityitem = new EntityItem(worldObj, this.xCoord, this.yCoord + 1, this.zCoord, new ItemStack(Item.getItemFromBlock(TCBlocks.autoSwtichStand), 1));
                         float f3 = 0.05F;

--- a/src/main/java/train/common/tile/switchStand/TileCircleSwitchStand.java
+++ b/src/main/java/train/common/tile/switchStand/TileCircleSwitchStand.java
@@ -2,6 +2,7 @@ package train.common.tile.switchStand;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.Item;
@@ -34,7 +35,7 @@ public class TileCircleSwitchStand extends TileSwitch {
         if (!worldObj.isRemote) {
             if (updateTicks % 20 == 0) {
                 if (!this.worldObj.isAirBlock(this.xCoord, this.yCoord + 1, this.zCoord)) {
-                    Block block = this.worldObj.getBlock(this.xCoord, this.yCoord + 1, this.zCoord);
+                    Block block = CommonUtil.getBlockAt(this.worldObj, this.xCoord, this.yCoord + 1, this.zCoord);
                     if (block != null) {
                         EntityItem entityitem = new EntityItem(worldObj, this.xCoord, this.yCoord + 1, this.zCoord, new ItemStack(Item.getItemFromBlock(TCBlocks.circleSwitchStand), 1));
                         float f3 = 0.05F;

--- a/src/main/java/train/common/tile/switchStand/TileMILWSwitchStand.java
+++ b/src/main/java/train/common/tile/switchStand/TileMILWSwitchStand.java
@@ -2,6 +2,7 @@ package train.common.tile.switchStand;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.Item;
@@ -35,7 +36,7 @@ public class TileMILWSwitchStand extends TileSwitch {
         if (!worldObj.isRemote) {
             if (updateTicks % 20 == 0) {
                 if (!this.worldObj.isAirBlock(this.xCoord, this.yCoord + 1, this.zCoord)) {
-                    Block block = this.worldObj.getBlock(this.xCoord, this.yCoord + 1, this.zCoord);
+                    Block block = CommonUtil.getBlockAt(this.worldObj, this.xCoord, this.yCoord + 1, this.zCoord);
                     if (block != null) {
                         EntityItem entityitem = new EntityItem(worldObj, this.xCoord, this.yCoord + 1, this.zCoord, new ItemStack(Item.getItemFromBlock(TCBlocks.MILWSwitchStand), 1));
                         float f3 = 0.05F;

--- a/src/main/java/train/common/tile/switchStand/TileOWOSwitchStand.java
+++ b/src/main/java/train/common/tile/switchStand/TileOWOSwitchStand.java
@@ -2,6 +2,7 @@ package train.common.tile.switchStand;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.Item;
@@ -35,7 +36,7 @@ public class TileOWOSwitchStand extends TileSwitch {
         if (!worldObj.isRemote) {
             if (updateTicks % 20 == 0) {
                 if (!this.worldObj.isAirBlock(this.xCoord, this.yCoord + 1, this.zCoord)) {
-                    Block block = this.worldObj.getBlock(this.xCoord, this.yCoord + 1, this.zCoord);
+                    Block block = CommonUtil.getBlockAt(this.worldObj, this.xCoord, this.yCoord + 1, this.zCoord);
                     if (block != null) {
                         EntityItem entityitem = new EntityItem(worldObj, this.xCoord, this.yCoord + 1, this.zCoord, new ItemStack(Item.getItemFromBlock(TCBlocks.owoSwitchStand), 1));
                         float f3 = 0.05F;

--- a/src/main/java/train/common/tile/switchStand/TileOWOYardSwitchStand.java
+++ b/src/main/java/train/common/tile/switchStand/TileOWOYardSwitchStand.java
@@ -2,6 +2,7 @@ package train.common.tile.switchStand;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.Item;
@@ -37,7 +38,7 @@ public class TileOWOYardSwitchStand extends TileSwitch {
         if (!worldObj.isRemote) {
             if (updateTicks % 20 == 0) {
                 if (!this.worldObj.isAirBlock(this.xCoord, this.yCoord + 1, this.zCoord)) {
-                    Block block = this.worldObj.getBlock(this.xCoord, this.yCoord + 1, this.zCoord);
+                    Block block = CommonUtil.getBlockAt(this.worldObj, this.xCoord, this.yCoord + 1, this.zCoord);
                     if (block != null) {
                         EntityItem entityitem = new EntityItem(worldObj, this.xCoord, this.yCoord + 1, this.zCoord, new ItemStack(Item.getItemFromBlock(TCBlocks.owoYardSwitchStand), 1));
                         float f3 = 0.05F;

--- a/src/main/java/train/common/tile/switchStand/TileSpeedSign.java
+++ b/src/main/java/train/common/tile/switchStand/TileSpeedSign.java
@@ -2,6 +2,7 @@ package train.common.tile.switchStand;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
@@ -20,7 +21,7 @@ public class TileSpeedSign extends TileRenderFacing {
 	}
 	public void setSkinstate(int skinstate) {
 		this.skinstate = skinstate;
-		worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+		CommonUtil.markBlockForUpdate(worldObj, xCoord, yCoord, zCoord);
 
 	}
 
@@ -34,7 +35,7 @@ public class TileSpeedSign extends TileRenderFacing {
 		} else {
 			skinstate++;
 		}
-		worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+		CommonUtil.markBlockForUpdate(worldObj, xCoord, yCoord, zCoord);
 	}
 
 

--- a/src/main/java/train/common/tile/switchStand/TileSwitchStand.java
+++ b/src/main/java/train/common/tile/switchStand/TileSwitchStand.java
@@ -2,6 +2,7 @@ package train.common.tile.switchStand;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.Item;
@@ -35,7 +36,7 @@ public class TileSwitchStand extends TileSwitch {
         if (!worldObj.isRemote) {
             if (updateTicks % 20 == 0) {
                 if (!this.worldObj.isAirBlock(this.xCoord, this.yCoord + 1, this.zCoord)) {
-                    Block block = this.worldObj.getBlock(this.xCoord, this.yCoord + 1, this.zCoord);
+                    Block block = CommonUtil.getBlockAt(this.worldObj, this.xCoord, this.yCoord + 1, this.zCoord);
                     if (block != null) {
                         EntityItem entityitem = new EntityItem(worldObj, this.xCoord, this.yCoord + 1, this.zCoord, new ItemStack(Item.getItemFromBlock(TCBlocks.switchStand), 1));
                         float f3 = 0.05F;

--- a/src/main/java/train/common/tile/switchStand/TilekSignal.java
+++ b/src/main/java/train/common/tile/switchStand/TilekSignal.java
@@ -2,6 +2,7 @@ package train.common.tile.switchStand;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.Item;
@@ -38,7 +39,7 @@ public class TilekSignal extends TileTraincraft {
         if (!worldObj.isRemote) {
             if (updateTicks % 20 == 0) {
                 if (!this.worldObj.isAirBlock(this.xCoord, this.yCoord + 1, this.zCoord)) {
-                    Block block = this.worldObj.getBlock(this.xCoord, this.yCoord + 1, this.zCoord);
+                    Block block = CommonUtil.getBlockAt(this.worldObj, this.xCoord, this.yCoord + 1, this.zCoord);
                     if (block != null) {
                         EntityItem entityitem = new EntityItem(worldObj, this.xCoord, this.yCoord + 1, this.zCoord, new ItemStack(Item.getItemFromBlock(BlockIDs.kSignal.block), 1));
                         float f3 = 0.05F;

--- a/src/main/java/train/common/tile/switchStand/TileoverheadWire.java
+++ b/src/main/java/train/common/tile/switchStand/TileoverheadWire.java
@@ -2,6 +2,7 @@ package train.common.tile.switchStand;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.Item;
@@ -28,7 +29,7 @@ public class TileoverheadWire extends TileTraincraft {
         if (!worldObj.isRemote) {
             if (updateTicks % 20 == 0) {
                 if (!this.worldObj.isAirBlock(this.xCoord, this.yCoord + 1, this.zCoord)) {
-                    Block block = this.worldObj.getBlock(this.xCoord, this.yCoord + 1, this.zCoord);
+                    Block block = CommonUtil.getBlockAt(this.worldObj, this.xCoord, this.yCoord + 1, this.zCoord);
                     if (block != null) {
                         EntityItem entityitem = new EntityItem(worldObj, this.xCoord, this.yCoord + 1, this.zCoord, new ItemStack(Item.getItemFromBlock(BlockIDs.overheadWire.block), 1));
                         float f3 = 0.05F;

--- a/src/main/java/train/common/tile/switchStand/TileoverheadWireDouble.java
+++ b/src/main/java/train/common/tile/switchStand/TileoverheadWireDouble.java
@@ -2,6 +2,7 @@ package train.common.tile.switchStand;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.Item;
@@ -28,7 +29,7 @@ public class TileoverheadWireDouble extends TileTraincraft {
         if (!worldObj.isRemote) {
             if (updateTicks % 20 == 0) {
                 if (!this.worldObj.isAirBlock(this.xCoord, this.yCoord + 1, this.zCoord)) {
-                    Block block = this.worldObj.getBlock(this.xCoord, this.yCoord + 1, this.zCoord);
+                    Block block = CommonUtil.getBlockAt(this.worldObj, this.xCoord, this.yCoord + 1, this.zCoord);
                     if (block != null) {
                         EntityItem entityitem = new EntityItem(worldObj, this.xCoord, this.yCoord + 1, this.zCoord, new ItemStack(Item.getItemFromBlock(BlockIDs.overheadWireDouble.block), 1));
                         float f3 = 0.05F;

--- a/src/main/java/train/common/tile/switchStand/TilesignalSpanish.java
+++ b/src/main/java/train/common/tile/switchStand/TilesignalSpanish.java
@@ -2,6 +2,7 @@ package train.common.tile.switchStand;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.Block;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.Item;
@@ -22,7 +23,7 @@ public class TilesignalSpanish extends TileSwitch {
 
     public void setState(int st){
         state = st;
-        worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+        CommonUtil.markBlockForUpdate(worldObj, xCoord, yCoord, zCoord);
     }
 
     public int getState(){
@@ -57,7 +58,7 @@ public class TilesignalSpanish extends TileSwitch {
         if (!worldObj.isRemote) {
             if (updateTicks % 20 == 0) {
                 if (!this.worldObj.isAirBlock(this.xCoord, this.yCoord + 1, this.zCoord)) {
-                    Block block = this.worldObj.getBlock(this.xCoord, this.yCoord + 1, this.zCoord);
+                    Block block = CommonUtil.getBlockAt(this.worldObj, this.xCoord, this.yCoord + 1, this.zCoord);
                     if (block != null) {
                         EntityItem entityitem = new EntityItem(worldObj, this.xCoord, this.yCoord + 1, this.zCoord, new ItemStack(Item.getItemFromBlock(BlockIDs.signalSpanish.block), 1));
                         float f3 = 0.05F;

--- a/src/main/java/train/common/wellcar/BlockFiftyThreeFootContainer.java
+++ b/src/main/java/train/common/wellcar/BlockFiftyThreeFootContainer.java
@@ -1,5 +1,6 @@
 package train.common.wellcar;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.Entity;
@@ -10,7 +11,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -122,7 +122,7 @@ public class BlockFiftyThreeFootContainer extends BlockContainer {
     @Override
     public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune) {
         ArrayList<ItemStack> ret = super.getDrops(world, x, y, z, metadata, fortune);
-        ItemStack stack = new ItemStack(world.getBlock(x, y, z), 1, metadata);
+        ItemStack stack = new ItemStack(CommonUtil.getBlockAt(world, x, y, z), 1, metadata);
 
         TileFortyFootContainer te = world.getTileEntity(x, y,z) instanceof TileFortyFootContainer ? (TileFortyFootContainer)world.getTileEntity(x,y,z) : null;
 
@@ -195,7 +195,7 @@ public class BlockFiftyThreeFootContainer extends BlockContainer {
     public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase player, ItemStack stack)
     {
         TileFortyFootContainer te = (TileFortyFootContainer) world.getTileEntity(x, y, z);
-        int playerYaw = MathHelper.floor_double((player.rotationYaw / 90.0F) + 2.5D) & 3;
+        int playerYaw = CommonUtil.floorDouble((player.rotationYaw / 90.0F) + 2.5D) & 3;
 
         if (te != null && stack.getTagCompound() != null)
         {

--- a/src/main/java/train/common/wellcar/BlockFortyFootContainer.java
+++ b/src/main/java/train/common/wellcar/BlockFortyFootContainer.java
@@ -1,5 +1,6 @@
 package train.common.wellcar;
 
+import ebf.tim.utility.CommonUtil;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.Entity;
@@ -10,7 +11,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -122,7 +122,7 @@ public class BlockFortyFootContainer extends BlockContainer {
     @Override
     public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune) {
         ArrayList<ItemStack> ret = super.getDrops(world, x, y, z, metadata, fortune);
-        ItemStack stack = new ItemStack(world.getBlock(x, y, z), 1, metadata);
+        ItemStack stack = new ItemStack(CommonUtil.getBlockAt(world, x, y, z), 1, metadata);
 
         TileFortyFootContainer te = world.getTileEntity(x, y,z) instanceof TileFortyFootContainer ? (TileFortyFootContainer)world.getTileEntity(x,y,z) : null;
 
@@ -195,7 +195,7 @@ public class BlockFortyFootContainer extends BlockContainer {
     public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase player, ItemStack stack)
     {
         TileFortyFootContainer te = (TileFortyFootContainer) world.getTileEntity(x, y, z);
-        int playerYaw = MathHelper.floor_double((player.rotationYaw / 90.0F) + 2.5D) & 3;
+        int playerYaw = CommonUtil.floorDouble((player.rotationYaw / 90.0F) + 2.5D) & 3;
 
         if (te != null && stack.getTagCompound() != null)
         {


### PR DESCRIPTION
Below is slop description. TLDR refactored easy callsites through the existing common util functions. Some functionality is not exactly 1:1 and is thus excluded for now.

## LLM Usage
Yes, I used an LLM to generate this PR.


## Commits (one per batch)
1. Route block access, meta, and notify calls through CommonUtil
   - MathHelper.floor_double -> CommonUtil.floorDouble (135)
   - world.getBlock -> CommonUtil.getBlockAt (World/WorldClient receivers) (110)
   - world.getBlockMetadata -> CommonUtil.getBlockFacing (66)
   - world.markBlockForUpdate -> CommonUtil.markBlockForUpdate (48)
   - Math.pow -> CommonUtil.power, Math.PI/180 -> CommonUtil.radianF
2. Replace raw atan2 and degree-conversion calls with CommonUtil (atan2degreesf LUT, bit-identical radian in updateRider)
3. Delete TraincraftUtil duplicates of CommonUtil (isRailBlockAt, atan2f, atan2degreesf, LUT table, degreesF); 23 call sites re-pointed; TraincraftUtil 127 -> 78 lines
4. Route sound playback through CommonUtil (19 sites; forward-compat hook for the 1.11 SoundEvent rework, no-op in 1.7)
5. Use CommonUtil.setBlockMeta for block placement/activation updates (14 safe sites; quiet flag-0/1 sites, per-tick TE paths, and ItemTCRail rail placement deferred pending review)
6. Route client-side lang lookups through CommonUtil.translate (55 sites; adds missing-lang-key logging; server-reachable sites keep StatCollector)

## Intentionally not migrated
- 0-arg TileTCRail.getBlockMetadata() — TC's own method, not the Mojang API
- IBlockAccess-typed receivers (CommonUtil.getBlockAt/markBlockForUpdate take World)
- EntityBogie Math.pow over double[] (power is float-only)
- javazoom/** (vendored MP3 decoder) and fexcraft/** (vendored renderer)
- setBlockMetadataWithNotify sites using quiet flags (0/1) or per-tick TE contexts, and the 47-site ItemTCRail placement path — behavior change risk, needs maintainer call
- soundManager.playSound GUI click sounds (no CommonUtil equivalent)

## Verification
- ./gradlew compileJava green after every batch
- All replacements verified against CommonUtil signatures (read + javadoc); no behavior changes intended